### PR TITLE
Add helper to persist dialog responses in memory

### DIFF
--- a/memory/memory_updater.py
+++ b/memory/memory_updater.py
@@ -54,6 +54,27 @@ def auto_update_memory(user_id, message, intent=None, entities=None):
     save_memory({user_id: memory_data})
 
 
+def update_memory(user_id, message, response, intent=None, entities=None):
+    """Kullanıcı mesajını ve yanıtı history'ye ekler."""
+    auto_update_memory(user_id, message, intent=intent, entities=entities)
+
+    memory_data = load_user_memory(user_id)
+    if "history" not in memory_data:
+        memory_data["history"] = []
+
+    if memory_data["history"]:
+        memory_data["history"][-1]["response"] = response
+    else:
+        memory_data["history"].append({
+            "message": message,
+            "response": response,
+            "intent": intent,
+            "entities": entities,
+        })
+
+    save_memory({user_id: memory_data})
+
+
 def get_user_memory(user_id):
     """Kullanıcının tam hafızasını döner."""
     return load_user_memory(user_id)


### PR DESCRIPTION
## Summary
- add an update_memory helper that records responses alongside requests in the user history store
- keep dialog manager using the new helper so generated replies are saved with their originating messages

## Testing
- pytest (fails: ModuleNotFoundError: No module named 'core')

------
https://chatgpt.com/codex/tasks/task_e_68db81b3467483279ffdc07c57b48237