### PR TITLE
Add config access helpers for module management

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -14,6 +14,10 @@ class ConfigManager:
             print(f"[ConfigManager] YAML yüklenemedi: {e}")
             return {}
 
+    def load_config(self):
+        """Return the cached configuration dictionary."""
+        return self.config or {}
+
     def get(self, key, default=None):
         keys = key.split(".")
         data = self.config
@@ -23,3 +27,15 @@ class ConfigManager:
             else:
                 return default
         return data
+
+    def get_active_modules(self):
+        """Return the list of active modules from the configuration."""
+        modules = self.get("modules.active", default=None)
+        if isinstance(modules, list):
+            return modules
+        return []
+
+
+def load_config():
+    """Backward-compatible helper to load configuration settings."""
+    return ConfigManager().load_config()


### PR DESCRIPTION
## Summary
- add `ConfigManager.load_config` and `ConfigManager.get_active_modules` helpers
- expose a module-level `load_config` wrapper to preserve existing imports

## Testing
- python - <<'PY'
import sys, types

class _ChatCompletion:
    @staticmethod
    def create(**kwargs):
        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="stub"))])

openai_stub = types.SimpleNamespace(ChatCompletion=_ChatCompletion, api_key=None)
sys.modules['openai'] = openai_stub
sys.modules['dialog.response_generator'] = types.SimpleNamespace(generate_response=lambda *args, **kwargs: "stub")
sys.modules['integration.web_search_mod'] = types.SimpleNamespace(search_duckduckgo=lambda query: "results")

from integration.api_connector import AIConnector
from main import initialize_system

connector = AIConnector()
print('AIConnector provider:', connector.provider)
print('Model keys:', list(connector.models.keys()))

initialize_system()
PY

------
https://chatgpt.com/codex/tasks/task_e_68db81b0bf2883278d873ac07359bc0b