### PR TITLE
Add resilient API helper with offline fallback

### DIFF
--- a/integration/api_connector.py
+++ b/integration/api_connector.py
@@ -1,7 +1,62 @@
-import openai
+from typing import Any, Dict, Optional
+
+try:
+    import openai  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
+
 from core.config_manager import load_config
 from dialog.response_generator import generate_response
 from integration.web_search_mod import search_duckduckgo
+
+
+def _build_stub_response(url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return a deterministic offline response for API calls."""
+
+    params = params or {}
+    ordered_params = {key: params[key] for key in sorted(params)}
+    return {
+        "status": "stub",
+        "url": url,
+        "params": ordered_params,
+        "data": f"stub-response-for-{url}",
+    }
+
+
+def call_api(url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Lightweight API helper that gracefully falls back to a stub response.
+
+    The function attempts to perform a real HTTP GET using the requests library.
+    When the client library is unavailable or a network error occurs, the
+    function returns a deterministic stub response so that tests can run
+    without external dependencies.
+    """
+
+    params = params or {}
+
+    try:
+        import requests  # Local import to avoid mandatory dependency.
+    except ImportError:
+        return _build_stub_response(url, params)
+
+    try:
+        response = requests.get(url, params=params, timeout=5)
+        response.raise_for_status()
+        content_type = response.headers.get("Content-Type", "")
+        payload: Any
+        if content_type.startswith("application/json"):
+            payload = response.json()
+        else:
+            payload = response.text
+
+        return {
+            "status": "ok",
+            "url": url,
+            "params": params,
+            "data": payload,
+        }
+    except Exception:
+        return _build_stub_response(url, params)
 
 class AIConnector:
     def __init__(self):
@@ -12,7 +67,12 @@ class AIConnector:
 
     def chat(self, message, user_memory="", context=""):
         try:
-            if self.provider == "openai":
+            if (
+                self.provider == "openai"
+                and openai
+                and isinstance(self.keys, dict)
+                and self.keys.get("openai")
+            ):
                 openai.api_key = self.keys["openai"]
                 messages = [
                     {"role":"system", "content":"You are Konuşan Tohum AI."},


### PR DESCRIPTION
## Summary
- add a lightweight `call_api` helper that falls back to a deterministic stub when HTTP requests are unavailable
- make the OpenAI dependency optional so configuration without credentials can still use the offline response path

## Testing
- pytest *(fails: package imports such as `core` are not discoverable in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db81baccdc8327b4905d4a945b0a66