### PR TITLE
Implement persona builder, response generator, and tone adjuster APIs

### DIFF
--- a/dialog/response_generator.py
+++ b/dialog/response_generator.py
@@ -27,6 +27,50 @@ def generate_response(message: str) -> str:
         return f"[Hata] Yanıt üretilemedi: {e}"
 
 
+RULE_BASED_RESPONSES = {
+    "greeting": "Merhaba! Size nasıl yardımcı olabilirim?",
+    "goodbye": "Görüşmek üzere! Yardıma ihtiyacınız olursa buradayım.",
+    "thanks": "Rica ederim! Başka bir konuda destek ister misiniz?",
+    "help": "Elbette, hangi konuda yardıma ihtiyacınız var?"
+}
+
+
+def _entity_summary(entities):
+    if not entities:
+        return ""
+
+    if isinstance(entities, dict):
+        items = [f"{key}: {value}" for key, value in entities.items()]
+    else:
+        items = [str(entity) for entity in entities]
+    return ", ".join(items)
+
+
+def generate(intent, entities, context, user_id=None):
+    """Niyet, varlıklar ve bağlamı kullanarak yanıt üretir."""
+
+    intent_key = (intent or "").lower()
+
+    if intent_key in RULE_BASED_RESPONSES:
+        base_response = RULE_BASED_RESPONSES[intent_key]
+        entity_text = _entity_summary(entities)
+        if entity_text:
+            base_response += f" (Belirttiğiniz bilgiler: {entity_text})"
+        return base_response
+
+    if context:
+        latest_message = context[-1].get("message", "")
+    else:
+        latest_message = intent or "Merhaba"
+
+    response = generate_response(latest_message)
+
+    if isinstance(response, str):
+        return response
+
+    return str(response)
+
+
 if __name__ == "__main__":
     # Test amaçlı
     test_input = "Merhaba, sen kimsin?"

--- a/dialog/tone_adjuster.py
+++ b/dialog/tone_adjuster.py
@@ -1,23 +1,36 @@
 # dialog/tone_adjuster.py
-from nlp.emotion_tracker import get_emotion
+
 
 class ToneAdjuster:
-    def __init__(self):
-        pass
+    """Metni belirtilen tona göre ayarlayan yardımcı sınıf."""
 
-    def adjust(self, user_id, text):
-        emotion = get_emotion(user_id)
-        if not emotion:
+    TONE_SUFFIXES = {
+        "positive": " 😊",
+        "encouraging": " 💪",
+        "neutral": "",
+        "empathetic": " 🤝",
+        "negative": " 💭"
+    }
+
+    def adjust(self, text, tone):
+        if not text:
+            return ""
+
+        if not tone:
             return text
 
-        if emotion == "pozitif":
-            return text + " 😊"
-        elif emotion == "negatif":
-            return text + " 💭"
-        return text
+        suffix = self.TONE_SUFFIXES.get(tone.lower())
+        if suffix is None:
+            return text
+
+        return f"{text}{suffix}"
+
 
 # Global örnek
 tone_adjuster = ToneAdjuster()
 
-def adjust_tone(user_id, text):
-    return tone_adjuster.adjust(user_id, text)
+
+def adjust(text, tone):
+    """Kısa yol fonksiyon."""
+
+    return tone_adjuster.adjust(text, tone)

--- a/nlp/persona_builder.py
+++ b/nlp/persona_builder.py
@@ -1,4 +1,8 @@
 # nlp/persona_builder.py
+from copy import deepcopy
+
+from memory.memory_updater import load_user_memory
+
 
 def get_persona(style="learner"):
     personas = {
@@ -7,14 +11,16 @@ def get_persona(style="learner"):
             "style_prompt": (
                 "Sen dost canlısı, sıcak ve pozitif bir yapay zekasın. "
                 "Kullanıcıya samimi şekilde cevap ver."
-            )
+            ),
+            "tone": "positive"
         },
         "helper": {
             "name": "Tohum",
             "style_prompt": (
                 "Sen öğretici, açıklayıcı ve kullanıcıya yardımcı olan bir yapay zekasın. "
                 "Karmaşık konuları basit ve anlaşılır şekilde açıkla."
-            )
+            ),
+            "tone": "neutral"
         },
         "learner": {
             "name": "Tohum",
@@ -24,8 +30,51 @@ def get_persona(style="learner"):
                 "Her cevapta öğrendiğini kabul et, öğretildiğini göster, "
                 "ve konuşmayı bağlamdan kopmadan sürdür. "
                 "Kendini geliştiren bir asistan gibi davran."
-            )
+            ),
+            "tone": "encouraging"
         }
     }
 
     return personas.get(style, personas["learner"])
+
+
+def build_persona(user_id, style=None):
+    """Kullanıcının tercihlerini dikkate alarak persona oluşturur."""
+
+    user_memory = load_user_memory(user_id)
+    user_profile = user_memory.get("profile", {}) if isinstance(user_memory, dict) else {}
+
+    resolved_style = (
+        style
+        or user_profile.get("preferred_style")
+        or user_profile.get("style")
+        or "learner"
+    )
+
+    base_persona = deepcopy(get_persona(resolved_style))
+    base_persona.setdefault("name", "Tohum")
+    base_persona["style"] = resolved_style
+    base_persona["user_id"] = user_id
+
+    default_tones = {
+        "friendly": "positive",
+        "helper": "neutral",
+        "learner": "encouraging"
+    }
+
+    persona_tone = (
+        user_profile.get("preferred_tone")
+        or user_profile.get("tone")
+        or base_persona.get("tone")
+        or default_tones.get(resolved_style, "neutral")
+    )
+    base_persona["tone"] = persona_tone
+
+    if user_profile:
+        base_persona["profile"] = user_profile
+
+    preferences = user_memory.get("preferences") if isinstance(user_memory, dict) else None
+    if preferences:
+        base_persona["preferences"] = preferences
+
+    return base_persona


### PR DESCRIPTION
## Summary
- add a persona builder that combines stored user preferences with the existing templates
- extend the response generator with a generate() helper that supports simple rule-based replies
- expose a tone adjuster that formats responses based on the resolved tone metadata

## Testing
- python -m compileall nlp/persona_builder.py dialog/response_generator.py dialog/tone_adjuster.py

------
https://chatgpt.com/codex/tasks/task_e_68db8bcddbd483279b9ed337299a8e40