### PR TITLE
Add list-based web search helper

### DIFF
--- a/core/core_engine.py
+++ b/core/core_engine.py
@@ -3,7 +3,8 @@ from nlp.nlp_engine import preprocess_text
 from nlp.entity_extractor import extract_entities
 from nlp.context_manager import update_context
 from dialog.response_generator import generate_response
-from integration.web_search_mod import search_duckduckgo
+from integration.web_search_mod import search
+
 
 def process_message(user_id, message):
     if not message or not message.strip():
@@ -38,9 +39,12 @@ def process_message(user_id, message):
     # 5. Yanıt eksikse web aramasıyla destekle
     if not response or "bilgi yok" in response.lower():
         try:
-            external_info = search_duckduckgo(message)
-            response = f"{external_info} (Kaynak: DuckDuckGo)"
+            search_results = search(message)
+            if search_results:
+                response = f"{search_results[0]} (Kaynak: DuckDuckGo)"
+            else:
+                response = (response or "") + "\n⚠️ Web araması sonuç vermedi."
         except Exception:
-            response += "\n⚠️ Web araması yapılamadı."
+            response = (response or "") + "\n⚠️ Web araması yapılamadı."
 
     return response

--- a/integration/api_connector.py
+++ b/integration/api_connector.py
@@ -1,7 +1,6 @@
 import openai
 from core.config_manager import load_config
 from dialog.response_generator import generate_response
-from integration.web_search_mod import search_duckduckgo
 
 class AIConnector:
     def __init__(self):

--- a/integration/web_search_mod.py
+++ b/integration/web_search_mod.py
@@ -1,13 +1,28 @@
 import requests
 
+
 def search_duckduckgo(query):
     url = "https://api.duckduckgo.com/"
     params = {
         "q": query,
         "format": "json",
         "no_redirect": 1,
-        "no_html": 1
+        "no_html": 1,
     }
     response = requests.get(url, params=params)
+    response.raise_for_status()
     data = response.json()
-    return data.get("Abstract", "Üzgünüm, bu konuda bilgi bulamadım.")
+    abstract = data.get("Abstract")
+    if isinstance(abstract, str):
+        abstract = abstract.strip()
+    return abstract or None
+
+
+def search(query):
+    """Return DuckDuckGo search summaries as a list."""
+    result = search_duckduckgo(query)
+    if isinstance(result, str):
+        cleaned = result.strip()
+        if cleaned:
+            return [cleaned]
+    return []


### PR DESCRIPTION
## Summary
- add a `search` helper that wraps the DuckDuckGo summary response in a list
- update the core engine to consume the list-based search results and handle empty responses
- clean up the unused web search import in the API connector

## Testing
- not run (network-dependent tests)


------
https://chatgpt.com/codex/tasks/task_e_68db8bd78e50832793a6b9a023b8025b