### PR TITLE
Add config helper utilities and module activation list

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -14,6 +14,10 @@ class ConfigManager:
             print(f"[ConfigManager] YAML yüklenemedi: {e}")
             return {}
 
+    def load_config(self):
+        """Yüklü yapılandırma sözlüğünü döndür."""
+        return self.config
+
     def get(self, key, default=None):
         keys = key.split(".")
         data = self.config
@@ -23,3 +27,14 @@ class ConfigManager:
             else:
                 return default
         return data
+
+    def get_active_modules(self):
+        """Yapılandırmadan etkin modül listesini döndür."""
+        modules_section = self.config.get("modules", {}) if isinstance(self.config, dict) else {}
+        active_modules = modules_section.get("active", []) if isinstance(modules_section, dict) else []
+        return active_modules if isinstance(active_modules, list) else []
+
+
+def load_config():
+    """Yeni bir ConfigManager örneğinden yapılandırmayı döndür."""
+    return ConfigManager().load_config()

--- a/settings/settings.yaml
+++ b/settings/settings.yaml
@@ -11,6 +11,11 @@ models:
   openrouter: "openai/gpt-3.5-turbo"   # OpenRouter modeli
   offline: "google/flan-t5-large"      # HuggingFace offline modeli
 
+modules:
+  active:
+    - "dialog.response_generator"
+    - "integration.web_search_mod"
+
 api:
   provider: "openrouter"   # Buradan sağlayıcıyı seç: openai | openrouter | offline
 


### PR DESCRIPTION
## Summary
- add ConfigManager.load_config and get_active_modules helpers for easier access to configuration data
- expose a module-level load_config utility that returns a fresh configuration dictionary
- define the default list of active modules in settings/settings.yaml

## Testing
- pytest *(fails: import errors for package-style modules when running tests outside package context)*

------
https://chatgpt.com/codex/tasks/task_e_68db8bcd44fc83278a10d41c2481dd11