### PR TITLE
Add explicit memory update helper for dialog manager

### DIFF
--- a/memory/memory_updater.py
+++ b/memory/memory_updater.py
@@ -57,3 +57,21 @@ def auto_update_memory(user_id, message, intent=None, entities=None):
 def get_user_memory(user_id):
     """Kullanıcının tam hafızasını döner."""
     return load_user_memory(user_id)
+
+
+def update_memory(user_id, message, response):
+    """Kullanıcının mesaj/yanıt geçmişini günceller ve JSON bütünlüğünü doğrular."""
+    memory_data = load_user_memory(user_id)
+
+    history = memory_data.get("history", [])
+    history.append({
+        "message": message,
+        "response": response,
+    })
+    memory_data["history"] = history[-20:]
+
+    save_memory({user_id: memory_data})
+
+    # JSON yapısının bozulmadığını doğrula
+    with open(MEMORY_FILE, "r", encoding="utf-8") as f:
+        json.load(f)


### PR DESCRIPTION
## Summary
- add a dedicated update_memory helper that records message-response pairs and validates the JSON store
- wire dialog manager to call the new helper after generating a response

## Testing
- python -m compileall dialog/dialog_manager.py memory/memory_updater.py

------
https://chatgpt.com/codex/tasks/task_e_68db8bd914a08327ab24ee744b10d57e