### PR TITLE
Add offline fallback for AIConnector

### DIFF
--- a/dialog/response_generator.py
+++ b/dialog/response_generator.py
@@ -2,9 +2,19 @@
 
 from transformers import pipeline
 
-# Hugging Face'ten hazır pipeline (örnek: küçük bir model ile test için)
-# Daha güçlü bir model kullanmak istersen buradaki model adını değiştirebilirsin.
-generator = pipeline("text-generation", model="gpt2")
+from core.config_manager import ConfigManager
+
+_GENERATOR = None
+
+
+def _get_generator():
+    """Modeli tek seferde oluşturup önbelleğe al."""
+    global _GENERATOR
+    if _GENERATOR is None:
+        config = ConfigManager()
+        model_name = config.get("models.offline", "gpt2")
+        _GENERATOR = pipeline("text-generation", model=model_name)
+    return _GENERATOR
 
 
 def generate_response(message: str) -> str:
@@ -14,6 +24,7 @@ def generate_response(message: str) -> str:
     :return: Yapay zeka tarafından üretilen yanıt
     """
     try:
+        generator = _get_generator()
         response = generator(
             message,
             max_length=100,

--- a/integration/ai_connector.py
+++ b/integration/ai_connector.py
@@ -1,17 +1,21 @@
 # integration/ai_connector.py
 import requests
+
 from core.config_manager import ConfigManager
+from dialog.response_generator import generate_response
 
 class AIConnector:
     def __init__(self):
         self.config = ConfigManager()
+        self.provider = self.config.get("api.provider", "openai")
         self.api_key_openai = self.config.get("api_keys.openai")
         self.api_key_openrouter = self.config.get("api_keys.openrouter")
         self.model_openai = self.config.get("models.online", "gpt-4o-mini")
         self.model_openrouter = self.config.get("models.openrouter", "openai/gpt-3.5-turbo")
 
-    def chat(self, message, provider="openai"):
+    def chat(self, message, provider=None):
         response = None
+        provider = (provider or self.provider or "offline").lower()
 
         if provider == "openrouter" and self.api_key_openrouter:
             try:
@@ -27,6 +31,8 @@ class AIConnector:
                     return response
             except Exception as e:
                 print(f"[AIConnector] OpenRouter hatası: {e}")
+        if provider == "openrouter":
+            provider = "offline"
 
         if provider == "openai" and self.api_key_openai:
             try:
@@ -42,5 +48,10 @@ class AIConnector:
                     return response
             except Exception as e:
                 print(f"[AIConnector] OpenAI hatası: {e}")
+        if provider == "openai":
+            provider = "offline"
+
+        if provider == "offline" or not response:
+            return generate_response(message)
 
         return "Üzgünüm, şu anda cevap üretemiyorum."

--- a/settings/settings.yaml
+++ b/settings/settings.yaml
@@ -1,18 +1,15 @@
 api:
-  provider: "openrouter"    # Seçenekler: openai / openrouter / huggingface
+  provider: "openrouter"   # Sağlayıcıyı seç: openai | openrouter | offline (offline seçeneği API anahtarı gerektirmez ve models.offline kullanılır)
 
 api_keys:
   openai: ""
   openrouter: ""
-  huggingface: ""
+  huggingface: ""        # Offline modunda gerekmez.
 
 models:
   online: "gpt-4o-mini"                # OpenAI modeli
   openrouter: "openai/gpt-3.5-turbo"   # OpenRouter modeli
-  offline: "google/flan-t5-large"      # HuggingFace offline modeli
-
-api:
-  provider: "openrouter"   # Buradan sağlayıcıyı seç: openai | openrouter | offline
+  offline: "google/flan-t5-large"      # Offline mod için kullanılacak Hugging Face modeli
 
 memory:
   path: "memory/data/"                 # JSON dosyalarının saklanacağı klasör

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,12 +1,28 @@
 from integration.web_search_mod import search
 from integration.api_connector import call_api
+from integration.ai_connector import AIConnector
+
 
 def test_web_search():
     results = search("Antalya hava durumu")
     assert isinstance(results, list)
     print("✅ WebSearchMod test edildi.")
 
+
 def test_api_connector():
     response = call_api("https://api.example.com", {"q": "test"})
     assert response is not None
     print("✅ APIConnector test edildi.")
+
+
+def test_ai_connector_offline_fallback(monkeypatch):
+    connector = AIConnector()
+    connector.api_key_openai = ""
+    connector.api_key_openrouter = ""
+
+    monkeypatch.setattr("integration.ai_connector.generate_response", lambda message: "offline yanıt")
+
+    result = connector.chat("Merhaba")
+
+    assert isinstance(result, str)
+    assert result == "offline yanıt"


### PR DESCRIPTION
## Summary
- add an offline branch to `AIConnector.chat` that routes messages to the cached Hugging Face generator when API keys are unavailable or the offline provider is selected
- lazily initialise the dialog response generator with the configured `models.offline` value and document the offline option in the settings file
- cover the offline fallback path with a regression test that patches the generator output

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68dcc44f579c8327a3d5263e320bf45c