### PR TITLE
Handle transformer fallback in intent detector

### DIFF
--- a/nlp/intent_detector.py
+++ b/nlp/intent_detector.py
@@ -1,15 +1,35 @@
-from transformers import AutoTokenizer, AutoModelForSequenceClassification
-import torch
 from nlp.intent_loader import load_intents
 
+try:
+    from transformers import AutoTokenizer, AutoModelForSequenceClassification
+    import torch
+
+    _TRANSFORMERS_AVAILABLE = True
+except Exception:  # pragma: no cover - broad to catch import errors
+    AutoTokenizer = None
+    AutoModelForSequenceClassification = None
+    torch = None
+    _TRANSFORMERS_AVAILABLE = False
+
 class IntentDetector:
-    def __init__(self):
+    def __init__(self, load_transformer: bool = True):
         self.intents = load_intents()
         self.labels = list(self.intents.keys())
-        self.tokenizer = AutoTokenizer.from_pretrained("dbmdz/bert-base-turkish-cased")
-        self.model = AutoModelForSequenceClassification.from_pretrained(
-            "dbmdz/bert-base-turkish-cased"
-        )
+        self.tokenizer = None
+        self.model = None
+        self._model_available = False
+
+        if load_transformer and _TRANSFORMERS_AVAILABLE:
+            try:
+                self.tokenizer = AutoTokenizer.from_pretrained(
+                    "dbmdz/bert-base-turkish-cased"
+                )
+                self.model = AutoModelForSequenceClassification.from_pretrained(
+                    "dbmdz/bert-base-turkish-cased"
+                )
+                self._model_available = True
+            except Exception:
+                self._model_available = False
 
         # Manuel örnek eşleştirme için basit anahtar kelime haritası
         self.manual_map = {
@@ -33,14 +53,17 @@ class IntentDetector:
                 return intent
 
         # Model tabanlı tahmin
-        inputs = self.tokenizer(text, return_tensors="pt", truncation=True, padding=True)
-        with torch.no_grad():
-            outputs = self.model(**inputs)
-        logits = outputs.logits
-        predicted_class = torch.argmax(logits, dim=1).item()
+        if self._model_available:
+            inputs = self.tokenizer(
+                text, return_tensors="pt", truncation=True, padding=True
+            )
+            with torch.no_grad():
+                outputs = self.model(**inputs)
+            logits = outputs.logits
+            predicted_class = torch.argmax(logits, dim=1).item()
 
-        if 0 <= predicted_class < len(self.labels):
-            return self.labels[predicted_class]
+            if 0 <= predicted_class < len(self.labels):
+                return self.labels[predicted_class]
         return "unknown"
 
 # Global örnek

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -1,10 +1,15 @@
-from nlp.intent_detector import detect_intent
+from nlp.intent_detector import IntentDetector, detect_intent
 from nlp.entity_extractor import extract_entities
 
 def test_intent_detector():
     intent = detect_intent("Bugün hava nasıl?")
     assert intent in ["weather", "greeting", "unknown"]
     print("✅ IntentDetector test edildi.")
+
+def test_intent_detector_fallback_manual_map():
+    detector = IntentDetector(load_transformer=False)
+    intent = detector.detect("Merhaba, nasılsın?")
+    assert intent == "greeting"
 
 def test_entity_extractor():
     entities = extract_entities("Antalya'da hava durumu")


### PR DESCRIPTION
## Summary
- wrap transformer imports and model loading in try/except to tolerate missing dependencies
- add a manual-map fallback path when the transformer model is unavailable
- cover the fallback branch with a dedicated unit test

## Testing
- `pytest` *(fails: missing core, diagnostics, dialog, integration, nlp, security packages during collection)*
- `PYTHONPATH=. pytest tests/test_nlp.py` *(fails: missing optional dependency yaml during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc886976483278945d258181226cc