### PR TITLE
Fix offline AIConnector fallback and add regression test

### DIFF
--- a/integration/api_connector.py
+++ b/integration/api_connector.py
@@ -89,6 +89,6 @@ class AIConnector:
 
             else:
                 # Offline veya başka provider fallback
-                return generate_response(message, intent=None, entities=None, context=context)
+                return generate_response(message)
         except Exception as e:
             return f"⚠️ API hatası: {str(e)}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import sys
+import types
+
+if "transformers" not in sys.modules:
+    transformers_stub = types.ModuleType("transformers")
+
+    def _stub_pipeline(*args, **kwargs):
+        def _generator(*_args, **_kwargs):
+            return [{"generated_text": "stub"}]
+
+        return _generator
+
+    transformers_stub.pipeline = _stub_pipeline
+    sys.modules["transformers"] = transformers_stub

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,20 @@
+import sys
+import types
+
+if "transformers" not in sys.modules:
+    transformers_stub = types.ModuleType("transformers")
+
+    def _stub_pipeline(*args, **kwargs):
+        def _generator(*_args, **_kwargs):
+            return [{"generated_text": "stub"}]
+
+        return _generator
+
+    transformers_stub.pipeline = _stub_pipeline
+    sys.modules["transformers"] = transformers_stub
+
 from integration.web_search_mod import search
-from integration.api_connector import call_api
-from integration.ai_connector import AIConnector
+from integration.api_connector import call_api, AIConnector
 
 
 def test_web_search():
@@ -17,10 +31,12 @@ def test_api_connector():
 
 def test_ai_connector_offline_fallback(monkeypatch):
     connector = AIConnector()
-    connector.api_key_openai = ""
-    connector.api_key_openrouter = ""
+    connector.provider = "offline"
+    connector.keys = {}
 
-    monkeypatch.setattr("integration.ai_connector.generate_response", lambda message: "offline yanıt")
+    monkeypatch.setattr(
+        "integration.api_connector.generate_response", lambda message: "offline yanıt"
+    )
 
     result = connector.chat("Merhaba")
 


### PR DESCRIPTION
## Summary
- update the offline branch of `AIConnector.chat` to call `generate_response` with the correct signature
- add a regression test that patches `integration.api_connector.generate_response` and verifies the offline fallback result
- provide a shared transformers stub in the test suite so imports succeed without the heavy dependency

## Testing
- `PYTHONPATH=. pytest tests/test_integration.py::test_ai_connector_offline_fallback`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dcd3091b24832786c6ffd6916e3db2