### PR TITLE
Refine tone adjustment and dependency fallbacks

### DIFF
--- a/core/chat_api.py
+++ b/core/chat_api.py
@@ -3,7 +3,7 @@ from nlp.entity_extractor import extract_entities
 from nlp.context_manager import update_context, get_context
 from nlp.persona_builder import get_persona
 from dialog.response_generator import generate
-from dialog.tone_adjuster import adjust_tone
+from dialog.tone_adjuster import adjust
 
 
 def process_message(user_id, message):
@@ -35,7 +35,7 @@ def process_message(user_id, message):
 
     # Yanıt üretimi
     raw_response = generate(intent, entities, conversation_context)
-    final_response = adjust_tone(user_id, raw_response)
+    final_response = adjust(raw_response, tone)
 
     return final_response
 

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -1,5 +1,8 @@
 # core/config_manager.py
-import yaml
+try:
+    import yaml
+except ImportError:  # pragma: no cover - çevrimdışı ortamlara uyum
+    yaml = None
 
 class ConfigManager:
     def __init__(self, config_path="settings/settings.yaml"):
@@ -8,6 +11,8 @@ class ConfigManager:
 
     def _load_yaml(self):
         try:
+            if yaml is None:
+                return {}
             with open(self.config_path, "r", encoding="utf-8") as f:
                 return yaml.safe_load(f)
         except Exception as e:

--- a/dialog/__init__.py
+++ b/dialog/__init__.py
@@ -1,0 +1,9 @@
+"""Dialog modülü paket başlangıç dosyası."""
+
+__all__ = [
+    "dialog_manager",
+    "feedback_collector",
+    "openrouter_connector",
+    "response_generator",
+    "tone_adjuster",
+]

--- a/dialog/response_generator.py
+++ b/dialog/response_generator.py
@@ -1,10 +1,20 @@
 # dialog/response_generator.py
 
-from transformers import pipeline
+try:
+    from transformers import pipeline
+except ImportError:  # pragma: no cover - çevrimdışı ortamlara uyum
+    pipeline = None
 
 from core.config_manager import ConfigManager
 
 _GENERATOR = None
+
+
+class _FallbackGenerator:
+    """Dış bağımlılık olmadığında kullanılan basit üretici."""
+
+    def __call__(self, prompt, **kwargs):
+        return [{"generated_text": prompt}]
 
 
 def _get_generator():
@@ -13,7 +23,10 @@ def _get_generator():
     if _GENERATOR is None:
         config = ConfigManager()
         model_name = config.get("models.offline", "gpt2")
-        _GENERATOR = pipeline("text-generation", model=model_name)
+        if pipeline is None:
+            _GENERATOR = _FallbackGenerator()
+        else:
+            _GENERATOR = pipeline("text-generation", model=model_name)
     return _GENERATOR
 
 

--- a/dialog/tone_adjuster.py
+++ b/dialog/tone_adjuster.py
@@ -34,3 +34,9 @@ def adjust(text, tone):
     """Kısa yol fonksiyon."""
 
     return tone_adjuster.adjust(text, tone)
+
+
+def adjust_tone(text, tone):
+    """Geriye dönük uyumluluk sağlayan sarmalayıcı."""
+
+    return adjust(text, tone)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,9 @@
+"""Test yapılandırması için yardımcı fonksiyonlar."""
+
 import sys
-import types
+from pathlib import Path
 
-if "transformers" not in sys.modules:
-    transformers_stub = types.ModuleType("transformers")
 
-    def _stub_pipeline(*args, **kwargs):
-        def _generator(*_args, **_kwargs):
-            return [{"generated_text": "stub"}]
-
-        return _generator
-
-    transformers_stub.pipeline = _stub_pipeline
-    sys.modules["transformers"] = transformers_stub
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- update the chat API to call the new tone adjust helper and provide a backward compatible wrapper
- make the response generator and config manager resilient to missing optional dependencies
- add dialog package metadata and pytest configuration so tests can import project modules

## Testing
- pytest tests/test_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd7d803b083279e0b534314ebd73c