### PR TITLE
Pass context history list to response generator

### DIFF
--- a/core/chat_api.py
+++ b/core/chat_api.py
@@ -26,15 +26,8 @@ def process_message(user_id, message):
     tone = persona_data.get("tone") or persona_data.get("default_tone") or "neutral"
     persona_data.setdefault("tone", tone)
 
-    # Yanıt üretimi için zenginleştirilmiş bağlam
-    conversation_context = {
-        "history": context_history,
-        "persona": persona_data,
-        "tone": tone,
-    }
-
     # Yanıt üretimi
-    raw_response = generate(intent, entities, conversation_context)
+    raw_response = generate(intent, entities, context_history, user_id=user_id)
     final_response = adjust(raw_response, tone)
 
     return final_response

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def initialize_system():
 
     # Örnek mesaj işleme (ileride chat_api ile bağlanacak)
     if "dialog.response_generator" in modules:
-        response = modules["dialog.response_generator"].generate("selam", {}, {}, user_id="test_user")
+        response = modules["dialog.response_generator"].generate("selam", {}, [], user_id="test_user")
         print(f"\n🗣 Yanıt: {response}")
 
 # Doğrudan çalıştırıldığında sistem başlatılır

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -1,6 +1,6 @@
 from dialog.response_generator import generate
 
 def test_response_generator():
-    response = generate("greeting", {}, {})
+    response = generate("greeting", {}, [])
     assert isinstance(response, str)
     print("✅ ResponseGenerator test edildi.")


### PR DESCRIPTION
## Summary
- update chat API to pass the raw context history list directly to the response generator
- align example usage and dialog tests with the new interface

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcf0e7c3ec8327829e8160b3f0dae3