### PR TITLE
Handle missing requests dependency in OpenRouter connector

### DIFF
--- a/dialog/openrouter_connector.py
+++ b/dialog/openrouter_connector.py
@@ -1,5 +1,8 @@
 # dialog/openrouter_connector.py
-import requests
+try:
+    import requests  # type: ignore
+except ImportError:  # pragma: no cover - environment without requests
+    requests = None
 from core.config_manager import ConfigManager
 
 config = ConfigManager()
@@ -8,6 +11,10 @@ OPENROUTER_KEY = api_keys.get("openrouter")
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 
 def call_openrouter_api(prompt, model="openai/gpt-3.5-turbo"):
+    if requests is None:
+        raise RuntimeError(
+            "The 'requests' library is required to call the OpenRouter API, but it is not installed."
+        )
     headers = {"Authorization": f"Bearer {OPENROUTER_KEY}"}
     payload = {"model": model, "messages": [{"role": "user", "content": prompt}]}
     r = requests.post(OPENROUTER_URL, headers=headers, json=payload)

--- a/tests/test_openrouter_connector.py
+++ b/tests/test_openrouter_connector.py
@@ -1,0 +1,10 @@
+import pytest
+
+from dialog import openrouter_connector
+
+
+def test_call_openrouter_api_without_requests(monkeypatch):
+    monkeypatch.setattr(openrouter_connector, "requests", None)
+
+    with pytest.raises(RuntimeError, match="requests"):
+        openrouter_connector.call_openrouter_api("Hello")


### PR DESCRIPTION
## Summary
- gracefully handle missing requests dependency in the OpenRouter connector
- raise a clear runtime error when requests is unavailable before making API calls
- add a unit test covering the missing dependency scenario

## Testing
- pytest tests/test_openrouter_connector.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf8da4b188327ab9d1bb1ba34eab4