### PR TITLE
Gracefully handle missing requests dependency in AIConnector

### DIFF
--- a/integration/ai_connector.py
+++ b/integration/ai_connector.py
@@ -1,5 +1,8 @@
 # integration/ai_connector.py
-import requests
+try:
+    import requests
+except ImportError:  # pragma: no cover - optional dependency
+    requests = None
 
 from core.config_manager import ConfigManager
 from dialog.response_generator import generate_response
@@ -18,6 +21,8 @@ class AIConnector:
         provider = (provider or self.provider or "offline").lower()
 
         if provider == "openrouter" and self.api_key_openrouter:
+            if requests is None:
+                return generate_response(message)
             try:
                 headers = {"Authorization": f"Bearer {self.api_key_openrouter}"}
                 payload = {
@@ -35,6 +40,8 @@ class AIConnector:
             provider = "offline"
 
         if provider == "openai" and self.api_key_openai:
+            if requests is None:
+                return generate_response(message)
             try:
                 headers = {"Authorization": f"Bearer {self.api_key_openai}"}
                 payload = {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,8 @@
+import builtins
+import importlib
 import sys
 import types
+from unittest.mock import patch
 
 if "transformers" not in sys.modules:
     transformers_stub = types.ModuleType("transformers")
@@ -42,3 +45,32 @@ def test_ai_connector_offline_fallback(monkeypatch):
 
     assert isinstance(result, str)
     assert result == "offline yanıt"
+
+
+def test_integration_ai_connector_without_requests(monkeypatch):
+    monkeypatch.delitem(sys.modules, "integration.ai_connector", raising=False)
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "requests":
+            raise ImportError("No module named 'requests'")
+        return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        module = importlib.import_module("integration.ai_connector")
+
+    monkeypatch.setattr(
+        module,
+        "generate_response",
+        lambda message: "offline yanıt (requests yok)"
+    )
+
+    connector = module.AIConnector()
+    connector.api_key_openai = "dummy"
+
+    result = connector.chat("Merhaba", provider="openai")
+
+    assert result == "offline yanıt (requests yok)"
+
+    importlib.reload(module)


### PR DESCRIPTION
## Summary
- guard the optional `requests` import in `integration.ai_connector` and fall back to offline responses when it is unavailable
- add a regression test that reloads `integration.ai_connector` without `requests` to verify the offline fallback

## Testing
- pytest tests/test_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf8cfa1a88327962f1e2c03ef13b2