### PR TITLE
Handle new intent keys in rule-based responses

### DIFF
--- a/dialog/response_generator.py
+++ b/dialog/response_generator.py
@@ -51,12 +51,22 @@ def generate_response(message: str) -> str:
         return f"[Hata] Yanıt üretilemedi: {e}"
 
 
-RULE_BASED_RESPONSES = {
+_BASE_RULE_RESPONSES = {
     "greeting": "Merhaba! Size nasıl yardımcı olabilirim?",
     "goodbye": "Görüşmek üzere! Yardıma ihtiyacınız olursa buradayım.",
     "thanks": "Rica ederim! Başka bir konuda destek ister misiniz?",
     "help": "Elbette, hangi konuda yardıma ihtiyacınız var?"
 }
+
+_INTENT_ALIASES = {
+    "farewell": "goodbye",
+    "thank_you": "thanks",
+    "ask_help": "help",
+}
+
+RULE_BASED_RESPONSES = dict(_BASE_RULE_RESPONSES)
+for alias, target in _INTENT_ALIASES.items():
+    RULE_BASED_RESPONSES[alias] = _BASE_RULE_RESPONSES.get(target, "")
 
 
 def _entity_summary(entities):
@@ -74,6 +84,7 @@ def generate(intent, entities, context, user_id=None):
     """Niyet, varlıklar ve bağlamı kullanarak yanıt üretir."""
 
     intent_key = (intent or "").lower()
+    intent_key = _INTENT_ALIASES.get(intent_key, intent_key)
 
     if intent_key in RULE_BASED_RESPONSES:
         base_response = RULE_BASED_RESPONSES[intent_key]

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -1,6 +1,28 @@
-from dialog.response_generator import generate
+import pytest
 
-def test_response_generator():
-    response = generate("greeting", {}, [])
+from dialog.response_generator import RULE_BASED_RESPONSES, generate
+
+
+@pytest.mark.parametrize(
+    "intent,expected_key",
+    [
+        ("greeting", "greeting"),
+        ("ask_help", "help"),
+        ("farewell", "goodbye"),
+        ("thank_you", "thanks"),
+    ],
+)
+def test_rule_based_responses(intent, expected_key):
+    response = generate(intent, {}, [])
+    assert response == RULE_BASED_RESPONSES[expected_key]
+
+
+@pytest.mark.parametrize(
+    "intent",
+    ["ask_help", "farewell", "thank_you"],
+)
+def test_rule_based_aliases_present(intent):
+    """Yeni niyet anahtarları için kural tabanlı yanıt döndürülmeli."""
+    response = generate(intent, {}, [])
     assert isinstance(response, str)
-    print("✅ ResponseGenerator test edildi.")
+    assert response


### PR DESCRIPTION
## Summary
- map new intent identifiers to existing rule-based responses
- normalize intents before lookup to support new aliases
- add dialog tests covering ask_help, farewell, and thank_you scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de1488f0b88327904c23dc186ade60