### PR TITLE
Add configuration validation and structured module loading errors

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -1,8 +1,228 @@
 # core/config_manager.py
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, MutableMapping, Tuple
+
 try:
     import yaml
 except ImportError:  # pragma: no cover - çevrimdışı ortamlara uyum
     yaml = None
+
+
+class ConfigError(Exception):
+    """Base sınıf."""
+
+
+class ConfigLoadError(ConfigError):
+    """YAML dosyası okunamazsa fırlatılır."""
+
+
+@dataclass
+class ConfigValidationError(ConfigError):
+    errors: List[str]
+
+    def __str__(self) -> str:  # pragma: no cover - küçük yardımcı
+        joined = "\n - ".join(self.errors)
+        return f"Ayar dosyası doğrulanamadı:\n - {joined}" if joined else "Ayar dosyası doğrulanamadı."
+
+
+@dataclass
+class ModuleValidationError(ConfigError):
+    errors: List[str]
+
+    def __str__(self) -> str:  # pragma: no cover - küçük yardımcı
+        joined = "\n - ".join(self.errors)
+        return f"Modül yapılandırması hatalı:\n - {joined}" if joined else "Modül yapılandırması hatalı."
+
+
+_CONFIG_SCHEMA: Dict[str, Any] = {
+    "api": {
+        "required": True,
+        "type": dict,
+        "schema": {"provider": {"type": str, "required": True}},
+    },
+    "api_keys": {
+        "required": True,
+        "type": dict,
+        "schema": {
+            "openai": {"type": str, "required": True},
+            "openrouter": {"type": str, "required": True},
+            "huggingface": {"type": str, "required": True},
+        },
+    },
+    "models": {
+        "required": True,
+        "type": dict,
+        "schema": {
+            "online": {"type": str, "required": True},
+            "openrouter": {"type": str, "required": True},
+            "offline": {"type": str, "required": True},
+        },
+    },
+    "memory": {
+        "required": True,
+        "type": dict,
+        "schema": {"path": {"type": str, "required": True}},
+    },
+    "context": {
+        "required": True,
+        "type": dict,
+        "schema": {"max_history": {"type": int, "required": True}},
+    },
+    "gui": {
+        "required": True,
+        "type": dict,
+        "schema": {
+            "title": {"type": str, "required": True},
+            "theme": {"type": str, "required": True},
+        },
+    },
+    "modules": {
+        "required": False,
+        "type": dict,
+        "schema": {
+            "active": {
+                "type": list,
+                "required": False,
+                "item_type": str,
+            }
+        },
+    },
+}
+
+
+def _strip_inline_comment(line: str) -> str:
+    result: List[str] = []
+    in_single = False
+    in_double = False
+    for char in line:
+        if char == "'" and not in_double:
+            in_single = not in_single
+            result.append(char)
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            result.append(char)
+            continue
+        if char == "#" and not in_single and not in_double:
+            break
+        result.append(char)
+    return "".join(result).rstrip()
+
+
+def _parse_scalar(value: str) -> Any:
+    if value in ("[]", "{}"):
+        return [] if value == "[]" else {}
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    if value.startswith("'") and value.endswith("'"):
+        return value[1:-1]
+    if value.isdigit():
+        try:
+            return int(value)
+        except ValueError:
+            pass
+    lowered = value.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    return value
+
+
+def _peek_next(lines: List[str], start: int) -> Optional[Tuple[int, str]]:
+    for index in range(start, len(lines)):
+        candidate = _strip_inline_comment(lines[index])
+        if candidate.strip():
+            indent = len(lines[index]) - len(lines[index].lstrip(" "))
+            return indent, candidate.lstrip()
+    return None
+
+
+def _simple_yaml_load(text: str) -> Dict[str, Any]:
+    root: Dict[str, Any] = {}
+    stack: List[Tuple[int, Any]] = [(-1, root)]
+    lines = text.splitlines()
+
+    for idx, raw_line in enumerate(lines):
+        processed = _strip_inline_comment(raw_line)
+        if not processed.strip():
+            continue
+
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        while len(stack) > 1 and indent <= stack[-1][0]:
+            stack.pop()
+
+        container = stack[-1][1]
+        line = processed.lstrip()
+
+        if line.startswith("- "):
+            if not isinstance(container, list):
+                raise ConfigLoadError("Liste öğesi beklenmeyen bir konumda bulundu.")
+            value_part = line[2:].strip()
+            container.append(_parse_scalar(value_part))
+            continue
+
+        key, sep, remainder = line.partition(":")
+        if not sep:
+            raise ConfigLoadError(f"Geçersiz satır: {line}")
+        key = key.strip()
+        value = remainder.strip()
+
+        if not value:
+            next_info = _peek_next(lines, idx + 1)
+            if next_info and next_info[0] > indent and next_info[1].startswith("- "):
+                new_container: Any = []
+            else:
+                new_container = {}
+            if isinstance(container, dict):
+                container[key] = new_container
+            else:
+                raise ConfigLoadError("Liste öğesine doğrudan anahtar atanamaz.")
+            stack.append((indent, new_container))
+        else:
+            parsed = _parse_scalar(value)
+            if isinstance(container, dict):
+                container[key] = parsed
+            else:
+                raise ConfigLoadError("Liste öğesine doğrudan anahtar atanamaz.")
+
+    return root
+
+
+def _validate_schema(schema: Dict[str, Any], data: MutableMapping[str, Any], path: str = "") -> List[str]:
+    errors: List[str] = []
+
+    for field, rules in schema.items():
+        field_path = f"{path}.{field}" if path else field
+        required = rules.get("required", False)
+        if field not in data or data[field] is None:
+            if required:
+                errors.append(f"'{field_path}' alanı zorunlu.")
+            continue
+
+        value = data[field]
+        expected_type = rules.get("type")
+        if expected_type and not isinstance(value, expected_type):
+            errors.append(
+                f"'{field_path}' alanı {expected_type.__name__} olmalı ancak {type(value).__name__} bulundu."
+            )
+            continue
+
+        nested_schema = rules.get("schema")
+        if nested_schema and isinstance(value, MutableMapping):
+            errors.extend(_validate_schema(nested_schema, value, field_path))
+
+        item_type = rules.get("item_type")
+        if item_type and isinstance(value, Iterable):
+            for index, item in enumerate(value):
+                if not isinstance(item, item_type):
+                    errors.append(
+                        f"'{field_path}[{index}]' {item_type.__name__} olmalı ancak {type(item).__name__} bulundu."
+                    )
+
+    return errors
+
 
 class ConfigManager:
     def __init__(self, config_path="settings/settings.yaml"):
@@ -11,13 +231,25 @@ class ConfigManager:
 
     def _load_yaml(self):
         try:
-            if yaml is None:
-                return {}
             with open(self.config_path, "r", encoding="utf-8") as f:
-                return yaml.safe_load(f)
-        except Exception as e:
-            print(f"[ConfigManager] YAML yüklenemedi: {e}")
-            return {}
+                raw_content = f.read()
+            if yaml is None:
+                loaded = _simple_yaml_load(raw_content)
+            else:
+                loaded = yaml.safe_load(raw_content) or {}
+        except FileNotFoundError as exc:  # pragma: no cover - temel IO
+            raise ConfigLoadError(f"Yapılandırma dosyası bulunamadı: {self.config_path}") from exc
+        except Exception as exc:  # pragma: no cover - yaml parse hataları
+            raise ConfigLoadError(f"Yapılandırma dosyası okunamadı: {exc}") from exc
+
+        if not isinstance(loaded, dict):
+            raise ConfigValidationError(["YAML içeriği geçerli bir sözlük değil."])
+
+        errors = _validate_schema(_CONFIG_SCHEMA, loaded)
+        if errors:
+            raise ConfigValidationError(errors)
+
+        return loaded
 
     def load_config(self):
         """Return the cached configuration dictionary."""
@@ -35,10 +267,31 @@ class ConfigManager:
 
     def get_active_modules(self):
         """Return the list of active modules from the configuration."""
-        modules = self.get("modules.active", default=None)
-        if isinstance(modules, list):
-            return modules
-        return []
+        modules = self.get("modules.active", default=[])
+        if modules is None:
+            return []
+        if not isinstance(modules, list):
+            raise ModuleValidationError(["'modules.active' bir liste olmalıdır."])
+
+        errors: List[str] = []
+        validated: List[str] = []
+        for index, module_name in enumerate(modules):
+            if not isinstance(module_name, str) or not module_name.strip():
+                errors.append(
+                    f"'modules.active[{index}]' boş olmayan bir modül yolu olmalıdır."
+                )
+                continue
+            try:
+                importlib.import_module(module_name)
+            except Exception as exc:
+                errors.append(f"'{module_name}' modülü yüklenemedi: {exc}")
+            else:
+                validated.append(module_name)
+
+        if errors:
+            raise ModuleValidationError(errors)
+
+        return validated
 
 
 def load_config():

--- a/core/module_loader.py
+++ b/core/module_loader.py
@@ -1,23 +1,51 @@
+from __future__ import annotations
+
 import importlib
 import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+
+logger = logging.getLogger("ModuleLoader")
+
+
+@dataclass
+class ModuleImportError(Exception):
+    module_name: str
+    original: Exception
+
+    def __str__(self) -> str:  # pragma: no cover - kolay okunurluk
+        return f"{self.module_name} modülü yüklenemedi: {self.original}"
+
+
+class ModuleLoadError(Exception):
+    def __init__(self, errors: Iterable[ModuleImportError], loaded_modules: Optional[Dict[str, object]] = None):
+        self.errors: List[ModuleImportError] = list(errors)
+        self.loaded_modules = loaded_modules or {}
+        message = "\n".join(str(error) for error in self.errors)
+        super().__init__(message)
+
 
 class ModuleLoader:
     def __init__(self, module_names):
         self.module_names = module_names
-        self.modules = {}
-        self.logger = logging.getLogger("ModuleLoader")
+        self.modules: Dict[str, object] = {}
 
     def load_all(self):
+        errors: List[ModuleImportError] = []
         for name in self.module_names:
             try:
                 module = importlib.import_module(name)
-                if hasattr(module, "initialize"):
-                    self.modules[name] = module.initialize()
-                else:
-                    self.modules[name] = module
-                self.logger.info(f"Modül yüklendi: {name}")
-            except Exception as e:
-                self.logger.error(f"Modül yüklenemedi: {name} → {e}")
+                instance = module.initialize() if hasattr(module, "initialize") else module
+                self.modules[name] = instance
+                logger.info("Modül yüklendi: %s", name)
+            except Exception as exc:
+                error = ModuleImportError(name, exc)
+                errors.append(error)
+                logger.error(str(error))
+
+        if errors:
+            raise ModuleLoadError(errors, self.modules)
 
     def get_module(self, name):
         return self.modules.get(name, None)

--- a/main.py
+++ b/main.py
@@ -1,18 +1,28 @@
-from core.config_manager import ConfigManager
-from core.module_loader import ModuleLoader
+from core.config_manager import ConfigError, ConfigManager
+from core.module_loader import ModuleLoadError, ModuleLoader
 from diagnostics.system_tester import SystemTester
 
 def initialize_system():
     print("🌱 Konuşan Tohum v1.0 başlatılıyor...")
 
     # Ayarları yükle
-    config = ConfigManager()
-    settings = config.load_config()
-    active_modules = config.get_active_modules()
+    try:
+        config = ConfigManager()
+        settings = config.load_config()
+        active_modules = config.get_active_modules()
+    except ConfigError as exc:
+        print(f"❌ Yapılandırma hatası: {exc}")
+        raise SystemExit(1) from exc
 
     # Modülleri yükle
     loader = ModuleLoader(active_modules)
-    loader.load_all()
+    try:
+        loader.load_all()
+    except ModuleLoadError as exc:
+        print("❌ Modüller yüklenirken hatalar oluştu:")
+        for error in exc.errors:
+            print(f" - {error}")
+        raise SystemExit(1) from exc
     modules = loader.get_all_modules()
 
     # Modül testi

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,87 @@
+import textwrap
+
+import pytest
+
+from core.config_manager import (
+    ConfigManager,
+    ConfigValidationError,
+    ModuleValidationError,
+)
+from core.module_loader import ModuleLoadError, ModuleLoader
+
+
+def _write_config(tmp_path, body: str):
+    path = tmp_path / "settings.yaml"
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+def test_missing_required_field_raises_validation_error(tmp_path):
+    config_body = textwrap.dedent(
+        """
+        api_keys:
+          openai: ""
+          openrouter: ""
+          huggingface: ""
+        """
+    )
+    config_path = _write_config(tmp_path, config_body)
+
+    with pytest.raises(ConfigValidationError) as exc_info:
+        ConfigManager(str(config_path))
+
+    assert "'api' alanı zorunlu" in str(exc_info.value)
+
+
+def test_invalid_modules_raise_module_validation_error(tmp_path):
+    config_body = textwrap.dedent(
+        """
+        api:
+          provider: "offline"
+
+        api_keys:
+          openai: ""
+          openrouter: ""
+          huggingface: ""
+
+        models:
+          online: "a"
+          openrouter: "b"
+          offline: "c"
+
+        memory:
+          path: "memory/data"
+
+        context:
+          max_history: 3
+
+        gui:
+          title: "Konuşan Tohum"
+          theme: "light"
+
+        modules:
+          active:
+            - tests.nonexistent_module
+            - "  "
+        """
+    )
+    config_path = _write_config(tmp_path, config_body)
+    manager = ConfigManager(str(config_path))
+
+    with pytest.raises(ModuleValidationError) as exc_info:
+        manager.get_active_modules()
+
+    message = str(exc_info.value)
+    assert "'modules.active[1]'" in message
+    assert "tests.nonexistent_module" in message
+
+
+def test_module_loader_reports_failed_imports():
+    loader = ModuleLoader(["math", "tests.missing_module_for_loader"])
+
+    with pytest.raises(ModuleLoadError) as exc_info:
+        loader.load_all()
+
+    error = exc_info.value
+    assert "tests.missing_module_for_loader" in str(error)
+    assert "math" in loader.get_all_modules()


### PR DESCRIPTION
## Summary
- add a schema-driven validator and lightweight YAML fallback loader to ConfigManager for descriptive config errors
- validate configured module imports and expose structured module loading exceptions to the CLI
- cover invalid configuration and module import failures with new pytest cases

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de1e903a20832795b43f4c71c0bfb1