### PR TITLE
Ensure atomic memory updates

### DIFF
--- a/memory/memory_updater.py
+++ b/memory/memory_updater.py
@@ -1,21 +1,49 @@
 import json
 import os
+import tempfile
+import threading
+from typing import Any, Dict
 
 MEMORY_FILE = "memory/user_memory.json"
 
-# Dosya yoksa oluştur
-if not os.path.exists("memory"):
-    os.makedirs("memory")
+_MEMORY_LOCK = threading.Lock()
 
-if not os.path.exists(MEMORY_FILE):
-    with open(MEMORY_FILE, "w", encoding="utf-8") as f:
-        json.dump({}, f, indent=2, ensure_ascii=False)
+
+def _ensure_memory_file() -> None:
+    """Ensure the backing memory file and its directory exist."""
+    directory = os.path.dirname(MEMORY_FILE) or "."
+    os.makedirs(directory, exist_ok=True)
+    if not os.path.exists(MEMORY_FILE):
+        with open(MEMORY_FILE, "w", encoding="utf-8") as f:
+            json.dump({}, f, indent=2, ensure_ascii=False)
+
+
+def _atomic_write_json(data: Dict[str, Any], file_path: str) -> None:
+    """Persist JSON data atomically using a temporary file and os.replace."""
+    directory = os.path.dirname(file_path) or "."
+    os.makedirs(directory, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=directory, delete=False
+    ) as tmp_file:
+        json.dump(data, tmp_file, indent=2, ensure_ascii=False)
+        tmp_file.flush()
+        os.fsync(tmp_file.fileno())
+        temp_name = tmp_file.name
+    os.replace(temp_name, file_path)
+
+
+def _load_all_memory() -> Dict[str, Any]:
+    _ensure_memory_file()
+    with open(MEMORY_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+_ensure_memory_file()
 
 
 def load_user_memory(user_id):
     """Kullanıcının hafızasını yükler."""
-    with open(MEMORY_FILE, "r", encoding="utf-8") as f:
-        all_memory = json.load(f)
+    all_memory = _load_all_memory()
     return all_memory.get(user_id, {})
 
 
@@ -23,15 +51,14 @@ def save_memory(user_memory_dict):
     """Tüm kullanıcı hafızasını kaydeder.
     user_memory_dict: {user_id: memory_data} şeklinde olmalı
     """
-    with open(MEMORY_FILE, "r", encoding="utf-8") as f:
-        all_memory = json.load(f)
+    with _MEMORY_LOCK:
+        all_memory = _load_all_memory()
 
-    # Hafızayı güncelle
-    for uid, mem in user_memory_dict.items():
-        all_memory[uid] = mem
+        # Hafızayı güncelle
+        for uid, mem in user_memory_dict.items():
+            all_memory[uid] = mem
 
-    with open(MEMORY_FILE, "w", encoding="utf-8") as f:
-        json.dump(all_memory, f, indent=2, ensure_ascii=False)
+        _atomic_write_json(all_memory, MEMORY_FILE)
 
 
 def auto_update_memory(user_id, message, intent=None, entities=None):
@@ -61,17 +88,19 @@ def get_user_memory(user_id):
 
 def update_memory(user_id, message, response):
     """Kullanıcının mesaj/yanıt geçmişini günceller ve JSON bütünlüğünü doğrular."""
-    memory_data = load_user_memory(user_id)
+    with _MEMORY_LOCK:
+        all_memory = _load_all_memory()
+        memory_data = all_memory.get(user_id, {})
 
-    history = memory_data.get("history", [])
-    history.append({
-        "message": message,
-        "response": response,
-    })
-    memory_data["history"] = history[-20:]
+        history = memory_data.get("history", [])
+        history.append({
+            "message": message,
+            "response": response,
+        })
+        memory_data["history"] = history[-20:]
+        all_memory[user_id] = memory_data
 
-    save_memory({user_id: memory_data})
+        _atomic_write_json(all_memory, MEMORY_FILE)
 
-    # JSON yapısının bozulmadığını doğrula
-    with open(MEMORY_FILE, "r", encoding="utf-8") as f:
-        json.load(f)
+        # JSON yapısının bozulmadığını doğrula
+        _load_all_memory()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,60 @@
+import json
+import threading
+
+import pytest
+
+from memory import memory_updater
+
+
+def _configure_temporary_memory(monkeypatch, tmp_path):
+    memory_file = tmp_path / "user_memory.json"
+    monkeypatch.setattr(memory_updater, "MEMORY_FILE", str(memory_file), raising=False)
+    memory_updater._ensure_memory_file()
+    return memory_file
+
+
+def test_update_memory_is_atomic_on_failure(monkeypatch, tmp_path):
+    memory_file = _configure_temporary_memory(monkeypatch, tmp_path)
+    user_id = "user"
+
+    memory_updater.update_memory(user_id, "hello", "world")
+    initial_state = json.loads(memory_file.read_text(encoding="utf-8"))
+
+    def fail_atomic_write_json(*args, **kwargs):  # pragma: no cover - behaviour tested via exception
+        raise RuntimeError("simulated failure")
+
+    monkeypatch.setattr(memory_updater, "_atomic_write_json", fail_atomic_write_json)
+
+    with pytest.raises(RuntimeError):
+        memory_updater.update_memory(user_id, "new", "response")
+
+    assert json.loads(memory_file.read_text(encoding="utf-8")) == initial_state
+
+
+def test_update_memory_concurrent_access(monkeypatch, tmp_path):
+    _configure_temporary_memory(monkeypatch, tmp_path)
+
+    user_id = "concurrent-user"
+    message_count = 10
+
+    def worker(idx: int) -> None:
+        message = f"message-{idx}"
+        response = f"response-{idx}"
+        memory_updater.update_memory(user_id, message, response)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(message_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    history = memory_updater.load_user_memory(user_id).get("history", [])
+    assert len(history) == message_count
+
+    expected_pairs = {
+        (f"message-{idx}", f"response-{idx}")
+        for idx in range(message_count)
+    }
+    actual_pairs = {(item.get("message"), item.get("response")) for item in history}
+
+    assert expected_pairs == actual_pairs


### PR DESCRIPTION
## Summary
- refactor the memory updater to persist history entries atomically with temp files and a process-wide lock
- update shared memory helpers to use the new atomic write logic
- add unit tests covering failure rollbacks and concurrent history updates

## Testing
- pytest tests/test_memory.py

------
https://chatgpt.com/codex/tasks/task_e_68de1e8b94048327a473011074472033