### PR TITLE
Add resilient HTTP sessions and injectable web search clients

### DIFF
--- a/integration/api_connector.py
+++ b/integration/api_connector.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 try:
@@ -5,8 +8,101 @@ try:
 except ImportError:  # pragma: no cover - optional dependency
     openai = None  # type: ignore
 
+try:  # pragma: no cover - optional dependency
+    import requests
+    from requests.adapters import HTTPAdapter
+except ImportError:  # pragma: no cover - gracefully handle missing requests
+    requests = None  # type: ignore
+    HTTPAdapter = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from urllib3.util import Retry
+except ImportError:  # pragma: no cover - gracefully handle missing urllib3
+    Retry = None  # type: ignore
+
 from core.config_manager import load_config
 from dialog.response_generator import generate_response
+
+
+@dataclass(frozen=True)
+class HTTPSettings:
+    """Configuration container for outbound HTTP calls."""
+
+    timeout: float = 10.0
+    max_retries: int = 3
+    backoff_factor: float = 0.5
+
+
+_SESSION_CACHE: Dict[HTTPSettings, "requests.Session"] = {}
+
+
+def _get_http_settings() -> HTTPSettings:
+    """Extract HTTP settings from configuration with sensible defaults."""
+
+    config = load_config() or {}
+    api_config = config.get("api") if isinstance(config, dict) else {}
+    if not isinstance(api_config, dict):
+        api_config = {}
+
+    timeout = api_config.get("timeout", 10)
+    retries = api_config.get("max_retries", 3)
+    backoff = api_config.get("backoff_factor", 0.5)
+
+    try:
+        timeout_value = float(timeout)
+    except (TypeError, ValueError):  # pragma: no cover - defensive branch
+        timeout_value = 10.0
+
+    try:
+        retries_value = int(retries)
+    except (TypeError, ValueError):  # pragma: no cover - defensive branch
+        retries_value = 3
+
+    try:
+        backoff_value = float(backoff)
+    except (TypeError, ValueError):  # pragma: no cover - defensive branch
+        backoff_value = 0.5
+
+    return HTTPSettings(
+        timeout=max(timeout_value, 0.1),
+        max_retries=max(retries_value, 0),
+        backoff_factor=max(backoff_value, 0.0),
+    )
+
+
+def _build_http_session(settings: HTTPSettings) -> Optional["requests.Session"]:
+    """Create (and cache) a requests session with retry/backoff configuration."""
+
+    if requests is None:  # pragma: no cover - executed when requests missing
+        return None
+
+    session = _SESSION_CACHE.get(settings)
+    if session is not None:
+        return session
+
+    session = requests.Session()
+
+    if HTTPAdapter is not None:
+        if Retry is not None:
+            retry = Retry(
+                total=settings.max_retries,
+                connect=settings.max_retries,
+                read=settings.max_retries,
+                status=settings.max_retries,
+                backoff_factor=settings.backoff_factor,
+                status_forcelist=(429, 500, 502, 503, 504),
+                allowed_methods=("GET", "POST"),
+                raise_on_status=False,
+            )
+            adapter = HTTPAdapter(max_retries=retry)
+        else:  # pragma: no cover - urllib3 missing
+            adapter = HTTPAdapter()
+
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+
+    _SESSION_CACHE[settings] = session
+    return session
 
 
 def _build_stub_response(url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -23,23 +119,17 @@ def _build_stub_response(url: str, params: Optional[Dict[str, Any]] = None) -> D
 
 
 def call_api(url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Lightweight API helper that gracefully falls back to a stub response.
-
-    The function attempts to perform a real HTTP GET using the requests library.
-    When the client library is unavailable or a network error occurs, the
-    function returns a deterministic stub response so that tests can run
-    without external dependencies.
-    """
+    """Lightweight API helper that gracefully falls back to a stub response."""
 
     params = params or {}
 
-    try:
-        import requests  # Local import to avoid mandatory dependency.
-    except ImportError:
+    settings = _get_http_settings()
+    session = _build_http_session(settings)
+    if session is None:  # pragma: no cover - requests missing
         return _build_stub_response(url, params)
 
     try:
-        response = requests.get(url, params=params, timeout=5)
+        response = session.get(url, params=params, timeout=settings.timeout)
         response.raise_for_status()
         content_type = response.headers.get("Content-Type", "")
         payload: Any
@@ -54,7 +144,16 @@ def call_api(url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any
             "params": params,
             "data": payload,
         }
-    except Exception:
+    except Exception as exc:
+        if requests is not None and isinstance(exc, requests.Timeout):
+            error_response = _build_stub_response(url, params)
+            error_response.update(
+                {
+                    "status": "timeout",
+                    "error": f"Request to {url} timed out after {settings.timeout} seconds.",
+                }
+            )
+            return error_response
         return _build_stub_response(url, params)
 
 class AIConnector:
@@ -75,32 +174,111 @@ class AIConnector:
             self.models = {}
         self.models.setdefault("online", "gpt-3.5-turbo")
         self.models.setdefault("offline", "konusan-tohum-offline")
+        self.models.setdefault("openrouter", "openai/gpt-3.5-turbo")
+
+        self.http_settings = _get_http_settings()
 
     def chat(self, message, user_memory="", context=""):
-        try:
-            if (
-                self.provider == "openai"
-                and openai
-                and isinstance(self.keys, dict)
-                and self.keys.get("openai")
-            ):
-                openai.api_key = self.keys["openai"]
-                messages = [
-                    {"role":"system", "content":"You are Konuşan Tohum AI."},
-                    {"role":"system", "content":f"User memory: {user_memory}"},
-                    {"role":"system", "content":f"Context: {context}"},
-                    {"role":"user", "content":message}
-                ]
-                response = openai.ChatCompletion.create(
-                    model=self.models["online"],
-                    messages=messages,
-                    temperature=0.7,
-                    max_tokens=300
-                )
-                return response.choices[0].message.content
+        provider = (self.provider or "offline").lower()
+        session = _build_http_session(self.http_settings)
 
-            else:
-                # Offline veya başka provider fallback
-                return generate_response(message)
-        except Exception as e:
-            return f"⚠️ API hatası: {str(e)}"
+        def _compose_messages() -> Dict[str, Any]:
+            return {
+                "model": self.models.get("online", "gpt-3.5-turbo"),
+                "messages": [
+                    {"role": "system", "content": "You are Konuşan Tohum AI."},
+                    {"role": "system", "content": f"User memory: {user_memory}"},
+                    {"role": "system", "content": f"Context: {context}"},
+                    {"role": "user", "content": message},
+                ],
+                "temperature": 0.7,
+                "max_tokens": 300,
+            }
+
+        def _handle_timeout(endpoint: str) -> str:
+            return (
+                f"⚠️ API hatası: Request to {endpoint} timed out after "
+                f"{self.http_settings.timeout} seconds."
+            )
+
+        try:
+            if provider == "openrouter" and self.keys.get("openrouter"):
+                if session is None:
+                    return generate_response(message)
+
+                headers = {
+                    "Authorization": f"Bearer {self.keys['openrouter']}",
+                    "Content-Type": "application/json",
+                }
+                payload = _compose_messages()
+                payload["model"] = self.models.get("openrouter", payload["model"])
+
+                try:
+                    response = session.post(
+                        "https://openrouter.ai/api/v1/chat/completions",
+                        headers=headers,
+                        json=payload,
+                        timeout=self.http_settings.timeout,
+                    )
+                    response.raise_for_status()
+                    data = response.json()
+                    content = (
+                        data.get("choices", [{}])[0]
+                        .get("message", {})
+                        .get("content")
+                    )
+                    if isinstance(content, str) and content.strip():
+                        return content
+                except Exception as exc:
+                    if requests is not None and isinstance(exc, requests.Timeout):
+                        return _handle_timeout("OpenRouter")
+                    return f"⚠️ API hatası: {exc}"
+                provider = "offline"
+
+            if provider == "openai" and self.keys.get("openai"):
+                if session is None and openai:
+                    try:
+                        openai.api_key = self.keys["openai"]
+                        payload = _compose_messages()
+                        messages = payload.pop("messages")
+                        response = openai.ChatCompletion.create(
+                            messages=messages,
+                            **payload,
+                        )
+                        return response.choices[0].message.content
+                    except Exception as exc:  # pragma: no cover - optional path
+                        return f"⚠️ API hatası: {exc}"
+
+                if session is None:
+                    return generate_response(message)
+
+                headers = {
+                    "Authorization": f"Bearer {self.keys['openai']}",
+                    "Content-Type": "application/json",
+                }
+                payload = _compose_messages()
+                try:
+                    response = session.post(
+                        "https://api.openai.com/v1/chat/completions",
+                        headers=headers,
+                        json=payload,
+                        timeout=self.http_settings.timeout,
+                    )
+                    response.raise_for_status()
+                    data = response.json()
+                    content = (
+                        data.get("choices", [{}])[0]
+                        .get("message", {})
+                        .get("content")
+                    )
+                    if isinstance(content, str) and content.strip():
+                        return content
+                except Exception as exc:
+                    if requests is not None and isinstance(exc, requests.Timeout):
+                        return _handle_timeout("OpenAI")
+                    return f"⚠️ API hatası: {exc}"
+                provider = "offline"
+
+            return generate_response(message)
+        except Exception as exc:  # pragma: no cover - defensive
+            return f"⚠️ API hatası: {exc}"

--- a/integration/web_search_mod.py
+++ b/integration/web_search_mod.py
@@ -12,7 +12,7 @@ remaining faithful to the behaviour the rest of the project expects.
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Protocol
 
 _OFFLINE_RESULTS: Dict[str, List[str]] = {
     "antalya hava durumu": [
@@ -28,12 +28,35 @@ def _normalise(query: str) -> str:
     return query.strip().lower()
 
 
-def search_duckduckgo(query: str) -> Optional[str]:
-    """Query the DuckDuckGo API if the requests dependency is available."""
+class SupportsGet(Protocol):
+    """Minimal protocol describing the part of requests used by the module."""
+
+    def get(self, url: str, params: Optional[Dict[str, Any]] = None, timeout: Optional[int] = None):
+        ...
+
+
+def _resolve_client(http_client: Optional[SupportsGet]) -> Optional[SupportsGet]:
+    if http_client is not None:
+        return http_client
 
     try:  # pragma: no cover - ImportError branch executed in tests
-        import requests
+        import requests  # type: ignore
+
+        return requests
     except ImportError:
+        return None
+
+
+def search_duckduckgo(
+    query: str,
+    *,
+    http_client: Optional[SupportsGet] = None,
+    timeout: int = 5,
+) -> Optional[str]:
+    """Query the DuckDuckGo API using the provided (or default) HTTP client."""
+
+    client = _resolve_client(http_client)
+    if client is None:
         return None
 
     url = "https://api.duckduckgo.com/"
@@ -45,7 +68,7 @@ def search_duckduckgo(query: str) -> Optional[str]:
     }
 
     try:
-        response = requests.get(url, params=params, timeout=5)
+        response = client.get(url, params=params, timeout=timeout)
         response.raise_for_status()
         data = response.json()
     except Exception:  # pragma: no cover - network disabled in tests
@@ -63,7 +86,12 @@ def _offline_search(query: str) -> List[str]:
     return _OFFLINE_RESULTS.get(_normalise(query), [])
 
 
-def search(query: str) -> List[str]:
+def search(
+    query: str,
+    *,
+    http_client: Optional[SupportsGet] = None,
+    timeout: int = 5,
+) -> List[str]:
     """Return DuckDuckGo search summaries as a list.
 
     The function attempts an online lookup first.  When that fails we
@@ -71,7 +99,7 @@ def search(query: str) -> List[str]:
     continue to operate in a fully isolated environment.
     """
 
-    result = search_duckduckgo(query)
+    result = search_duckduckgo(query, http_client=http_client, timeout=timeout)
     if isinstance(result, str):
         cleaned = result.strip()
         if cleaned:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,8 +16,11 @@ if "transformers" not in sys.modules:
     transformers_stub.pipeline = _stub_pipeline
     sys.modules["transformers"] = transformers_stub
 
+import pytest
+
+from integration import api_connector as connector_module
 from integration.web_search_mod import search
-from integration.api_connector import call_api, AIConnector
+from integration.api_connector import AIConnector, HTTPSettings, _build_http_session, call_api
 
 
 def test_web_search():
@@ -45,6 +48,68 @@ def test_ai_connector_offline_fallback(monkeypatch):
 
     assert isinstance(result, str)
     assert result == "offline yanıt"
+
+
+def test_http_session_applies_retry_configuration():
+    session = _build_http_session(HTTPSettings(timeout=2, max_retries=4, backoff_factor=1.5))
+    if session is None:  # pragma: no cover - requests missing
+        pytest.skip("requests library not available")
+
+    adapter = session.get_adapter("https://")
+    retry = getattr(adapter, "max_retries", None)
+
+    assert retry is not None
+    assert retry.total == 4
+    assert retry.backoff_factor == 1.5
+
+
+def test_call_api_timeout_surface_error(monkeypatch):
+    if connector_module.requests is None:
+        pytest.skip("requests library not available")
+
+    class TimeoutSession:
+        def get(self, *args, **kwargs):
+            raise connector_module.requests.Timeout("boom")
+
+    monkeypatch.setattr(connector_module, "_build_http_session", lambda *_args, **_kwargs: TimeoutSession())
+
+    result = call_api("https://timeout.test", {"foo": "bar"})
+
+    assert result["status"] == "timeout"
+    assert "timed out" in result["error"].lower()
+
+
+def test_search_falls_back_when_client_errors():
+    class FailingClient:
+        def get(self, *args, **kwargs):
+            raise RuntimeError("network down")
+
+    results = search("Antalya hava durumu", http_client=FailingClient())
+
+    assert results  # offline dataset populated
+    assert all(isinstance(item, str) for item in results)
+
+
+def test_ai_connector_openai_timeout_message(monkeypatch):
+    if connector_module.requests is None:
+        pytest.skip("requests library not available")
+
+    connector = AIConnector()
+    connector.provider = "openai"
+    connector.keys = {"openai": "dummy"}
+
+    class TimeoutSession:
+        def post(self, *args, **kwargs):
+            raise connector_module.requests.Timeout("boom")
+
+    monkeypatch.setattr(
+        "integration.api_connector._build_http_session",
+        lambda *_args, **_kwargs: TimeoutSession(),
+    )
+
+    message = connector.chat("Merhaba", user_memory="", context="")
+
+    assert "timed out" in message.lower()
 
 
 def test_integration_ai_connector_without_requests(monkeypatch):


### PR DESCRIPTION
## Summary
- add configurable HTTP session builder with retries/backoff for integration API calls and AIConnector providers
- expose timeout-specific messaging while ensuring OpenAI/OpenRouter requests share the same session policies
- refactor web search helpers to accept injectable HTTP clients and extend tests for retry/backoff and offline fallbacks

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68de1e8d16d48327a4cf32c6dec13a15