### PR TITLE
Add regression coverage and improve module validation

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -4,6 +4,22 @@ try:
 except ImportError:  # pragma: no cover - çevrimdışı ortamlara uyum
     yaml = None
 
+
+class ConfigurationError(Exception):
+    """Base exception for configuration issues."""
+
+
+class InvalidActiveModulesError(ConfigurationError):
+    """Raised when modules.active is missing or malformed."""
+
+    def __init__(self, invalid_value):
+        message = (
+            "modules.active must be a list of module import paths, "
+            f"received: {invalid_value!r}"
+        )
+        super().__init__(message)
+        self.invalid_value = invalid_value
+
 class ConfigManager:
     def __init__(self, config_path="settings/settings.yaml"):
         self.config_path = config_path
@@ -35,10 +51,21 @@ class ConfigManager:
 
     def get_active_modules(self):
         """Return the list of active modules from the configuration."""
+
         modules = self.get("modules.active", default=None)
-        if isinstance(modules, list):
-            return modules
-        return []
+        if modules is None:
+            return []
+
+        if not isinstance(modules, list):
+            raise InvalidActiveModulesError(modules)
+
+        invalid_entries = [
+            item for item in modules if not isinstance(item, str) or not item.strip()
+        ]
+        if invalid_entries:
+            raise InvalidActiveModulesError(invalid_entries)
+
+        return modules
 
 
 def load_config():

--- a/core/module_loader.py
+++ b/core/module_loader.py
@@ -1,6 +1,16 @@
 import importlib
 import logging
 
+
+class ModuleLoadError(ImportError):
+    """Raised when a configured module cannot be imported."""
+
+    def __init__(self, module_name, reason):
+        message = f"Failed to load module '{module_name}': {reason}"
+        super().__init__(message)
+        self.module_name = module_name
+        self.reason = reason
+
 class ModuleLoader:
     def __init__(self, module_names):
         self.module_names = module_names
@@ -9,6 +19,9 @@ class ModuleLoader:
 
     def load_all(self):
         for name in self.module_names:
+            if not isinstance(name, str) or not name.strip():
+                raise ModuleLoadError(name, "module path must be a non-empty string")
+
             try:
                 module = importlib.import_module(name)
                 if hasattr(module, "initialize"):
@@ -18,6 +31,7 @@ class ModuleLoader:
                 self.logger.info(f"Modül yüklendi: {name}")
             except Exception as e:
                 self.logger.error(f"Modül yüklenemedi: {name} → {e}")
+                raise ModuleLoadError(name, str(e)) from e
 
     def get_module(self, name):
         return self.modules.get(name, None)

--- a/integration/api_connector.py
+++ b/integration/api_connector.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Optional
+import time
+from typing import Any, Dict, Optional, Sequence
 
 try:
     import openai  # type: ignore
@@ -22,7 +23,16 @@ def _build_stub_response(url: str, params: Optional[Dict[str, Any]] = None) -> D
     }
 
 
-def call_api(url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+_RETRYABLE_STATUS_CODES: Sequence[int] = (429, 500, 502, 503, 504, 522, 524)
+
+
+def call_api(
+    url: str,
+    params: Optional[Dict[str, Any]] = None,
+    *,
+    max_retries: int = 3,
+    backoff_factor: float = 0.5,
+) -> Dict[str, Any]:
     """Lightweight API helper that gracefully falls back to a stub response.
 
     The function attempts to perform a real HTTP GET using the requests library.
@@ -38,24 +48,62 @@ def call_api(url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any
     except ImportError:
         return _build_stub_response(url, params)
 
-    try:
-        response = requests.get(url, params=params, timeout=5)
-        response.raise_for_status()
-        content_type = response.headers.get("Content-Type", "")
-        payload: Any
-        if content_type.startswith("application/json"):
-            payload = response.json()
-        else:
-            payload = response.text
+    # Bazı ortamlar requests.Timeout yerine exceptions.Timeout kullanır.
+    timeout_exceptions: Sequence[type] = tuple(
+        exc
+        for exc in (
+            getattr(requests, "Timeout", None),
+            getattr(getattr(requests, "exceptions", None), "Timeout", None),
+        )
+        if isinstance(exc, type)
+    )
 
-        return {
-            "status": "ok",
-            "url": url,
-            "params": params,
-            "data": payload,
-        }
-    except Exception:
-        return _build_stub_response(url, params)
+    last_error: Optional[Exception] = None
+    delay = backoff_factor
+
+    for attempt in range(max_retries):
+        try:
+            response = requests.get(url, params=params, timeout=5)
+        except Exception as exc:  # pragma: no cover - farklı hata türleri
+            last_error = exc
+        else:
+            status_code = getattr(response, "status_code", None)
+            if isinstance(status_code, int) and 200 <= status_code < 300:
+                content_type = response.headers.get("Content-Type", "")
+                payload: Any
+                if content_type.startswith("application/json"):
+                    payload = response.json()
+                else:
+                    payload = response.text
+
+                return {
+                    "status": "ok",
+                    "url": url,
+                    "params": params,
+                    "data": payload,
+                }
+
+            if status_code in _RETRYABLE_STATUS_CODES:
+                last_error = Exception(f"HTTP {status_code}")
+            else:
+                try:
+                    response.raise_for_status()
+                except Exception as exc:  # pragma: no cover - requests ayrıntıları
+                    last_error = exc
+                break
+
+        # Başarısız denemeler için geri çekilme uygula.
+        if attempt < max_retries - 1:
+            if timeout_exceptions and last_error and isinstance(last_error, timeout_exceptions):
+                pass
+            # Geri çekilme sırasında bekleme yapılırken hatalara toleranslı ol.
+            try:
+                time.sleep(delay)
+            except Exception:
+                pass
+            delay *= 2
+
+    return _build_stub_response(url, params)
 
 class AIConnector:
     def __init__(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = src
+addopts = -ra

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,8 @@
 from core.logger import Logger
-from core.config_manager import ConfigManager
+import pytest
+
+from core.config_manager import ConfigManager, InvalidActiveModulesError
+from core.module_loader import ModuleLoader, ModuleLoadError
 
 def test_logger():
     logger = Logger()
@@ -11,3 +14,54 @@ def test_config_manager():
     settings = config.load_config()
     assert isinstance(settings, dict)
     print("✅ ConfigManager test edildi.")
+
+
+def test_get_active_modules_rejects_invalid_type(monkeypatch):
+    monkeypatch.setattr(
+        ConfigManager,
+        "_load_yaml",
+        lambda self: {"modules": {"active": "dialog.response_generator"}},
+    )
+
+    manager = ConfigManager()
+    with pytest.raises(InvalidActiveModulesError) as exc:
+        manager.get_active_modules()
+
+    assert "modules.active" in str(exc.value)
+
+
+def test_get_active_modules_rejects_invalid_entries(monkeypatch):
+    monkeypatch.setattr(
+        ConfigManager,
+        "_load_yaml",
+        lambda self: {"modules": {"active": ["dialog.response_generator", ""]}},
+    )
+
+    manager = ConfigManager()
+    with pytest.raises(InvalidActiveModulesError) as exc:
+        manager.get_active_modules()
+
+    assert "module import paths" in str(exc.value)
+
+
+def test_module_loader_raises_for_invalid_entries():
+    loader = ModuleLoader(["", "dialog.response_generator"])
+
+    with pytest.raises(ModuleLoadError) as exc:
+        loader.load_all()
+
+    assert "module path" in str(exc.value)
+
+
+def test_module_loader_raises_when_import_fails(monkeypatch):
+    loader = ModuleLoader(["nonexistent.module"])
+
+    def fake_import(name):
+        raise ImportError("boom")
+
+    monkeypatch.setattr("core.module_loader.importlib.import_module", fake_import)
+
+    with pytest.raises(ModuleLoadError) as exc:
+        loader.load_all()
+
+    assert "nonexistent.module" in str(exc.value)

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dialog import response_generator as response_module
 from dialog.response_generator import RULE_BASED_RESPONSES, generate
 
 
@@ -26,3 +27,25 @@ def test_rule_based_aliases_present(intent):
     response = generate(intent, {}, [])
     assert isinstance(response, str)
     assert response
+
+
+def _stub_generator():
+    def _generate(prompt, **kwargs):
+        return [{"generated_text": f"echo::{prompt}"}]
+
+    return _generate
+
+
+def test_generate_response_alias(monkeypatch):
+    monkeypatch.setattr(response_module, "_GENERATOR", _stub_generator())
+
+    result = response_module.generate_response("merhaba")
+    assert result == "echo::merhaba"
+
+
+def test_generate_fallback_uses_generator(monkeypatch):
+    monkeypatch.setattr(response_module, "_GENERATOR", _stub_generator())
+
+    result = response_module.generate("bilinmeyen", {}, [], user_id="u1")
+    # Intent bilinmeyen olduğunda generate_response tetiklenmeli
+    assert result == "echo::bilinmeyen"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,6 +4,8 @@ import sys
 import types
 from unittest.mock import patch
 
+import pytest
+
 if "transformers" not in sys.modules:
     transformers_stub = types.ModuleType("transformers")
 
@@ -30,6 +32,76 @@ def test_api_connector():
     response = call_api("https://api.example.com", {"q": "test"})
     assert response is not None
     print("✅ APIConnector test edildi.")
+
+
+class _DummyResponse:
+    def __init__(self, status_code, data, headers=None):
+        self.status_code = status_code
+        self._data = data
+        self.headers = headers or {}
+        self.text = data if isinstance(data, str) else ""
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+@pytest.mark.parametrize(
+    "side_effects, expected_status, expected_calls",
+    [
+        ([
+            _DummyResponse(200, {"result": "ok"}, {"Content-Type": "application/json"})
+        ], "ok", 1),
+        ([
+            _DummyResponse(404, "not-found", {"Content-Type": "text/plain"})
+        ], "stub", 1),
+        ([
+            TimeoutError("boom"),
+            TimeoutError("boom"),
+            TimeoutError("boom"),
+        ], "stub", 3),
+    ],
+)
+def test_call_api_retry_logic(monkeypatch, side_effects, expected_status, expected_calls):
+    calls = []
+
+    class _RequestsStub:
+        class exceptions:
+            Timeout = TimeoutError
+
+        Timeout = TimeoutError
+
+        @staticmethod
+        def get(url, params=None, timeout=5):
+            index = len(calls)
+            if index >= len(side_effects):
+                raise AssertionError("Unexpected extra API call")
+            effect = side_effects[index]
+            calls.append((url, params, timeout))
+            if isinstance(effect, Exception):
+                raise effect
+            return effect
+
+    monkeypatch.setitem(sys.modules, "requests", _RequestsStub)
+    sleep_calls = []
+    monkeypatch.setattr("integration.api_connector.time.sleep", lambda duration: sleep_calls.append(duration))
+
+    response = call_api("https://example.com/api", {"payload": 1})
+
+    assert response["status"] == expected_status
+    assert len(calls) == expected_calls
+    if expected_status == "ok":
+        assert response["data"] == {"result": "ok"}
+    else:
+        assert response["data"].startswith("stub-response-for")
+
+    if expected_calls > 1:
+        assert sleep_calls, "Retry backoff should trigger sleep calls"
+    else:
+        assert not sleep_calls
 
 
 def test_ai_connector_offline_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
- add pytest configuration for the src-based layout and expand integration tests to cover API retry scenarios
- validate module configuration with descriptive errors and ensure dialog generators are accessible through both entry points
- cover configuration and module loader edge cases with new tests for misconfigured active modules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de1e8d890c832794bd9ad7b65bea62