### PR TITLE
Add unit test for memory update persistence

### DIFF
--- a/src/konusan_tohum/memory/__init__.py
+++ b/src/konusan_tohum/memory/__init__.py
@@ -1,1 +1,5 @@
-"""konusan_tohum.memory package."""
+"""Utility functions for working with persistent user memory."""
+
+from .memory_updater import update_memory
+
+__all__ = ["update_memory"]

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,20 @@
+import json
+
+from konusan_tohum.memory import update_memory
+
+
+def test_update_memory_appends_history_and_persists_json(tmp_path):
+    memory_file = tmp_path / "user_memory.json"
+    user_id = "test-user"
+
+    update_memory(user_id, "Selam", "Merhaba!", memory_file=memory_file)
+    update_memory(user_id, "Nasılsın?", "İyiyim, teşekkürler!", memory_file=memory_file)
+
+    with memory_file.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert user_id in data
+    history = data[user_id]["history"]
+    assert len(history) == 2
+    assert history[0] == {"message": "Selam", "response": "Merhaba!"}
+    assert history[1] == {"message": "Nasılsın?", "response": "İyiyim, teşekkürler!"}


### PR DESCRIPTION
## Summary
- expose the `update_memory` helper from the `konusan_tohum.memory` package
- add a focused unit test that verifies history persistence using a temporary directory

## Testing
- pytest tests/test_memory.py

------
https://chatgpt.com/codex/tasks/task_e_68de30cc61ac83278602e95fcb616fd8