### PR TITLE
Add deterministic parity test for dialog generators

### DIFF
--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -3,6 +3,7 @@ import pytest
 from konusan_tohum.dialog.response_generator import (
     RULE_BASED_RESPONSES,
     generate,
+    generate_response,
 )
 
 
@@ -29,3 +30,27 @@ def test_rule_based_aliases_present(intent):
     response = generate(intent, {}, [])
     assert isinstance(response, str)
     assert response
+
+
+def test_generate_matches_generate_response(monkeypatch):
+    """Serbest üretim akışında `generate` ve `generate_response` aynı çıktıyı vermeli."""
+
+    from konusan_tohum.dialog import response_generator as rg
+
+    class DummyGenerator:
+        def __call__(self, prompt, **kwargs):
+            return [{"generated_text": f"YANIT: {prompt}"}]
+
+    dummy_generator = DummyGenerator()
+
+    # Dış bağımlılıklar deterministik hale getiriliyor.
+    monkeypatch.setattr(rg, "_GENERATOR", None, raising=False)
+    monkeypatch.setattr(rg, "_get_generator", lambda: dummy_generator)
+
+    message = "Merhaba dünya"
+    expected = generate_response(message)
+    context = [{"message": message}]
+
+    result = generate(None, {}, context)
+
+    assert result == expected


### PR DESCRIPTION
## Summary
- extend dialog tests to validate that `generate` and `generate_response` produce identical outputs
- mock the response generator to ensure deterministic behavior during testing

## Testing
- pytest tests/test_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_68de30cf36148327af6d9f37b009f37c