### PR TITLE
Add retry-aware call_api handling and tests

### DIFF
--- a/src/konusan_tohum/integration/api_connector.py
+++ b/src/konusan_tohum/integration/api_connector.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any, Dict, Optional
 
 try:
@@ -38,24 +39,38 @@ def call_api(url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any
     except ImportError:
         return _build_stub_response(url, params)
 
-    try:
-        response = requests.get(url, params=params, timeout=5)
-        response.raise_for_status()
-        content_type = response.headers.get("Content-Type", "")
-        payload: Any
-        if content_type.startswith("application/json"):
-            payload = response.json()
-        else:
-            payload = response.text
+    max_retries = 3
+    backoff_factor = 0.5
+    timeout_seconds = 5
 
-        return {
-            "status": "ok",
-            "url": url,
-            "params": params,
-            "data": payload,
-        }
-    except Exception:
-        return _build_stub_response(url, params)
+    for attempt in range(max_retries):
+        try:
+            response = requests.get(url, params=params, timeout=timeout_seconds)
+            response.raise_for_status()
+            content_type = response.headers.get("Content-Type", "")
+            payload: Any
+            if content_type.startswith("application/json"):
+                payload = response.json()
+            else:
+                payload = response.text
+
+            return {
+                "status": "ok",
+                "url": url,
+                "params": params,
+                "data": payload,
+            }
+        except Exception:
+            if attempt < max_retries - 1:
+                delay = backoff_factor * (2 ** attempt)
+                try:
+                    time.sleep(delay)
+                except Exception:
+                    pass
+            else:
+                break
+
+    return _build_stub_response(url, params)
 
 class AIConnector:
     def __init__(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,7 +2,29 @@ import builtins
 import importlib
 import sys
 import types
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
+
+if "requests" not in sys.modules:
+    requests_stub = types.ModuleType("requests")
+
+    class RequestException(Exception):
+        pass
+
+    class HTTPError(RequestException):
+        pass
+
+    class Timeout(RequestException):
+        pass
+
+    requests_stub.exceptions = types.SimpleNamespace(
+        RequestException=RequestException,
+        HTTPError=HTTPError,
+        Timeout=Timeout,
+    )
+    requests_stub.get = lambda *args, **kwargs: None
+    sys.modules["requests"] = requests_stub
+
+import requests
 
 if "transformers" not in sys.modules:
     transformers_stub = types.ModuleType("transformers")
@@ -30,6 +52,66 @@ def test_api_connector():
     response = call_api("https://api.example.com", {"q": "test"})
     assert response is not None
     print("✅ APIConnector test edildi.")
+
+
+def test_call_api_success_response_structure():
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.headers = {"Content-Type": "application/json; charset=utf-8"}
+    mock_response.json.return_value = {"message": "ok"}
+
+    with patch("requests.get", return_value=mock_response) as mock_get, patch(
+        "konusan_tohum.integration.api_connector.time.sleep"
+    ) as mock_sleep:
+        result = call_api("https://api.example.com/data", {"q": "value"})
+
+    assert result == {
+        "status": "ok",
+        "url": "https://api.example.com/data",
+        "params": {"q": "value"},
+        "data": {"message": "ok"},
+    }
+    mock_get.assert_called_once_with(
+        "https://api.example.com/data", params={"q": "value"}, timeout=5
+    )
+    mock_sleep.assert_not_called()
+
+
+def test_call_api_http_error_retries_and_stub():
+    error_response = MagicMock()
+    error_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404")
+    error_response.headers = {}
+    error_response.text = ""
+
+    with patch("requests.get", return_value=error_response) as mock_get, patch(
+        "konusan_tohum.integration.api_connector.time.sleep"
+    ) as mock_sleep:
+        result = call_api("https://api.example.com/not-found", {"b": 2, "a": 1})
+
+    assert result == {
+        "status": "stub",
+        "url": "https://api.example.com/not-found",
+        "params": {"a": 1, "b": 2},
+        "data": "stub-response-for-https://api.example.com/not-found",
+    }
+    assert mock_get.call_count == 3
+    mock_sleep.assert_has_calls([call(0.5), call(1.0)])
+
+
+def test_call_api_timeout_retries_and_stub():
+    with patch("requests.get", side_effect=requests.exceptions.Timeout("timeout")) as mock_get, patch(
+        "konusan_tohum.integration.api_connector.time.sleep"
+    ) as mock_sleep:
+        result = call_api("https://api.example.com/slow", {"k": "v"})
+
+    assert result == {
+        "status": "stub",
+        "url": "https://api.example.com/slow",
+        "params": {"k": "v"},
+        "data": "stub-response-for-https://api.example.com/slow",
+    }
+    assert mock_get.call_count == 3
+    mock_sleep.assert_has_calls([call(0.5), call(1.0)])
 
 
 def test_ai_connector_offline_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
- add retry and exponential backoff handling to `call_api`
- expand integration tests to cover successful responses, HTTP errors, and timeouts via mocked `requests.get`

## Testing
- pytest tests/test_integration.py -q

------
https://chatgpt.com/codex/tasks/task_e_68de30cdcef883279205eb6e51ddaf12