### PR TITLE
Raise validation errors for invalid YAML settings

### DIFF
--- a/src/konusan_tohum/core/config_manager.py
+++ b/src/konusan_tohum/core/config_manager.py
@@ -2,6 +2,11 @@
 from pathlib import Path
 
 try:
+    from yaml import YAMLError
+except ImportError:  # pragma: no cover - çevrimdışı ortamlara uyum
+    YAMLError = Exception
+
+try:
     import yaml
 except ImportError:  # pragma: no cover - çevrimdışı ortamlara uyum
     yaml = None
@@ -16,16 +21,29 @@ class ConfigManager:
     def __init__(self, config_path=None):
         self.config_path = Path(config_path) if config_path else _DEFAULT_CONFIG_PATH
         self.config = self._load_yaml()
+        self._validate_config()
 
     def _load_yaml(self):
-        try:
-            if yaml is None:
-                return {}
-            with open(self.config_path, "r", encoding="utf-8") as f:
-                return yaml.safe_load(f)
-        except Exception as e:
-            print(f"[ConfigManager] YAML yüklenemedi: {e}")
+        if yaml is None:
             return {}
+
+        try:
+            with open(self.config_path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except FileNotFoundError as exc:  # pragma: no cover - gerçek dosya eksikliği
+            raise FileNotFoundError(
+                f"Yapılandırma dosyası bulunamadı: {self.config_path}"
+            ) from exc
+        except YAMLError as exc:
+            raise ValueError("Yapılandırma dosyası geçerli bir YAML değil.") from exc
+        except OSError as exc:  # pragma: no cover - IO hataları
+            raise ValueError(f"Yapılandırma dosyası okunamadı: {exc}") from exc
+
+        return data or {}
+
+    def _validate_config(self):
+        if not isinstance(self.config, dict):
+            raise ValueError("Yapılandırma sözlük formatında olmalıdır.")
 
     def load_config(self):
         """Return the cached configuration dictionary."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,13 +1,31 @@
+"""Çekirdek bileşenler için birim testleri."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
 from konusan_tohum.core.config_manager import ConfigManager
 from konusan_tohum.core.logger import Logger
+
 
 def test_logger():
     logger = Logger()
     logger.log("Test mesajı", level="INFO")
     print("✅ Logger test edildi.")
 
+
 def test_config_manager():
     config = ConfigManager()
     settings = config.load_config()
     assert isinstance(settings, dict)
     print("✅ ConfigManager test edildi.")
+
+
+def test_config_manager_invalid_yaml(tmp_path: Path):
+    invalid_settings = tmp_path / "settings.yaml"
+    invalid_settings.write_text("api: [unclosed", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        ConfigManager(config_path=invalid_settings)


### PR DESCRIPTION
## Summary
- validate configuration data during ConfigManager initialization and surface YAML parsing errors
- add a regression test ensuring invalid settings files raise a validation error

## Testing
- pytest tests/test_core.py

------
https://chatgpt.com/codex/tasks/task_e_68de30d0165c8327afa2147a14d4cc5f