### PR TITLE
Add module responsibility docstrings

### DIFF
--- a/chat_gui.py
+++ b/chat_gui.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum masaüstü sohbet arayüzü, hafıza ve bağlam hizmetleriyle etkileşim kuran Tkinter tabanlı demo istemcisini sunar."""
+
 import tkinter as tk
 from tkinter import scrolledtext
 import json

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum başlangıç yürütücüsü, çekirdek konfigürasyonu yükleyip modül altyapısını ayağa kaldırır ve sistem sağlığını doğrulayan bir örnek çalışma akışı sunar."""
+
 from konusan_tohum.core.config_manager import ConfigManager
 from konusan_tohum.core.module_loader import ModuleLoader
 from konusan_tohum.diagnostics.system_tester import SystemTester

--- a/src/konusan_tohum/__init__.py
+++ b/src/konusan_tohum/__init__.py
@@ -1,4 +1,4 @@
-"""konusan_tohum package root."""
+"""Konuşan Tohum paket kökü, çekirdekten NLP katmanına kadar tüm alanları tek bir dağıtılabilir yapı altında toplar."""
 
 __all__ = [
     "core",

--- a/src/konusan_tohum/core/__init__.py
+++ b/src/konusan_tohum/core/__init__.py
@@ -1,1 +1,1 @@
-"""konusan_tohum.core package."""
+"""Konuşan Tohum çekirdek katmanı, yapılandırma, modül yükleme, günlükleme ve mesaj işleme yardımcılarını barındırır."""

--- a/src/konusan_tohum/core/chat_api.py
+++ b/src/konusan_tohum/core/chat_api.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum sohbet API köprüsü, NLP niyet analizi, persona üretimi ve diyalog yanıtlayıcısını birleştirerek kullanıcı mesajlarını işler."""
+
 from konusan_tohum.nlp.intent_detector import detect_intent
 from konusan_tohum.nlp.entity_extractor import extract_entities
 from konusan_tohum.nlp.context_manager import update_context, get_context

--- a/src/konusan_tohum/core/config_manager.py
+++ b/src/konusan_tohum/core/config_manager.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum yapılandırma yöneticisi, YAML tabanlı ayar dosyalarını okuyarak etkin modülleri ve çalışma parametrelerini servis eder."""
+
 # core/config_manager.py
 from pathlib import Path
 

--- a/src/konusan_tohum/core/core_engine.py
+++ b/src/konusan_tohum/core/core_engine.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum çekirdek motoru, ön işleme, niyet ve varlık tespiti, bağlam güncellemesi ve web destekli yanıt üretimini orkestre eder."""
+
 from konusan_tohum.nlp.intent_detector import detect_intent
 from konusan_tohum.nlp.nlp_engine import preprocess_text
 from konusan_tohum.nlp.entity_extractor import extract_entities

--- a/src/konusan_tohum/core/logger.py
+++ b/src/konusan_tohum/core/logger.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum günlükleme yardımcı sınıfı, çekirdek akıştaki olayları zaman damgası ve önem seviyesiyle standart biçimde kayda geçirir."""
+
 import datetime
 
 class Logger:

--- a/src/konusan_tohum/core/module_loader.py
+++ b/src/konusan_tohum/core/module_loader.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum modül yükleyicisi, yapılandırmada tanımlı bileşenleri dinamik olarak içe aktarır ve kullanılabilir örnekleri yönetir."""
+
 import importlib
 import logging
 

--- a/src/konusan_tohum/diagnostics/__init__.py
+++ b/src/konusan_tohum/diagnostics/__init__.py
@@ -1,1 +1,1 @@
-"""konusan_tohum.diagnostics package."""
+"""Konuşan Tohum tanılama paketi, modül sağlığını izlemek için test, raporlama ve hata ayıklama yardımcılarını bir araya getirir."""

--- a/src/konusan_tohum/diagnostics/debug_tools.py
+++ b/src/konusan_tohum/diagnostics/debug_tools.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum tanılama izleyicileri, modül davranışını görünür kılmak için hafif izleme yardımcıları sağlar."""
+
 def trace(module_name):
     print(f"🔍 Modül izleniyor: {module_name}")
     # Geliştirici için izleme noktası

--- a/src/konusan_tohum/diagnostics/health_reporter.py
+++ b/src/konusan_tohum/diagnostics/health_reporter.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum sağlık raporlama aracı, sistem test sonuçlarını toplayıp anlaşılır özet metriklere dönüştürür."""
+
 def report(test_results):
     total = len(test_results)
     passed = sum(1 for result in test_results.values() if result)

--- a/src/konusan_tohum/diagnostics/system_tester.py
+++ b/src/konusan_tohum/diagnostics/system_tester.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum sistem testçisi, yüklenen modüllerin temel ping kontrollerini çalıştırarak çalışırlığı doğrular."""
+
 class SystemTester:
     def __init__(self, modules):
         self.modules = modules

--- a/src/konusan_tohum/dialog/__init__.py
+++ b/src/konusan_tohum/dialog/__init__.py
@@ -1,4 +1,4 @@
-"""Dialog modülü paket başlangıç dosyası."""
+"""Konuşan Tohum diyalog paketi, yanıt üretimi, ton ayarı, geri bildirim ve LLM bağlantı katmanlarını düzenler."""
 
 __all__ = [
     "dialog_manager",

--- a/src/konusan_tohum/dialog/dialog_manager.py
+++ b/src/konusan_tohum/dialog/dialog_manager.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum diyalog yöneticisi, yanıt üretimi ile hafıza güncellemelerini birleştirerek uçtan uca mesaj işleme sağlar."""
+
 # dialog/dialog_manager.py
 
 from konusan_tohum.dialog.response_generator import generate_response

--- a/src/konusan_tohum/dialog/feedback_collector.py
+++ b/src/konusan_tohum/dialog/feedback_collector.py
@@ -1,0 +1,1 @@
+"""Konuşan Tohum geri bildirim toplayıcısı, diyalog sonrası kullanıcı değerlendirmelerini kaydetmeye yönelik genişletilebilir bir yer tutucu sunar."""

--- a/src/konusan_tohum/dialog/openrouter_connector.py
+++ b/src/konusan_tohum/dialog/openrouter_connector.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum OpenRouter bağlayıcısı, yapılandırmadan aldığı anahtarlarla OpenRouter sohbet API çağrılarını yönetir ve gerekirse hataları yüzeye çıkarır."""
+
 # dialog/openrouter_connector.py
 try:
     import requests  # type: ignore

--- a/src/konusan_tohum/dialog/response_generator.py
+++ b/src/konusan_tohum/dialog/response_generator.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum yanıt üreticisi, kural tabanlı mesajlarla dönüştürücü modeller arasında köprü kurarak çevrimdışı senaryolara uyum sağlar."""
+
 # dialog/response_generator.py
 
 try:

--- a/src/konusan_tohum/dialog/tone_adjuster.py
+++ b/src/konusan_tohum/dialog/tone_adjuster.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum ton ayarlayıcısı, üretilen yanıtları persona tonlarına göre zenginleştirir."""
+
 # dialog/tone_adjuster.py
 
 

--- a/src/konusan_tohum/integration/__init__.py
+++ b/src/konusan_tohum/integration/__init__.py
@@ -1,1 +1,1 @@
-"""konusan_tohum.integration package."""
+"""Konuşan Tohum entegrasyon paketi, dış veri kaynakları ve üçüncü taraf servis bağlantılarına ait yardımcıları toplar."""

--- a/src/konusan_tohum/integration/ai_connector.py
+++ b/src/konusan_tohum/integration/ai_connector.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum AI bağlayıcısı, OpenAI ve OpenRouter sağlayıcılarıyla konuşmaları yöneten ve gerekirse çevrimdışı üreticiye dönen bir soyutlama sunar."""
+
 # integration/ai_connector.py
 try:
     import requests

--- a/src/konusan_tohum/integration/api_connector.py
+++ b/src/konusan_tohum/integration/api_connector.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum API bağlayıcısı, HTTP isteklerini yönetir, ağ hatalarında deterministik sahte yanıt üretir ve AI bağlayıcısını besler."""
+
 from typing import Any, Dict, Optional
 
 try:

--- a/src/konusan_tohum/integration/data_fetcher.py
+++ b/src/konusan_tohum/integration/data_fetcher.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum veri toplayıcısı, yerel ve uzak örnek veri kaynaklarına tek noktadan erişim sağlar."""
+
 def fetch(source):
     if source == "local":
         return {"data": "Yerel veri örneği"}

--- a/src/konusan_tohum/integration/db_manager.py
+++ b/src/konusan_tohum/integration/db_manager.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum veritabanı yöneticisi, prototip aşamasındaki anahtar-değer saklama ihtiyaçları için hafif bir arayüz sunar."""
+
 database = {}
 
 def insert(key, value):

--- a/src/konusan_tohum/integration/web_search_mod.py
+++ b/src/konusan_tohum/integration/web_search_mod.py
@@ -1,14 +1,4 @@
-"""Lightweight web search helpers used by the integration tests.
-
-The original project relies on the :mod:`requests` package to call the
-DuckDuckGo API.  The execution environment for the kata does not ship with
-third‑party dependencies, therefore importing :mod:`requests` raises a
-``ModuleNotFoundError`` and the tests fail during collection.  To keep the
-tests hermetic we perform the import lazily and gracefully fall back to
-deterministic offline data when the dependency or the network is
-unavailable.  The implementation purposely keeps the interface small while
-remaining faithful to the behaviour the rest of the project expects.
-"""
+"""Konuşan Tohum web arama modülü, DuckDuckGo sorgularını yöneten ve çevrimdışı durumlar için deterministik yanıtlar üreten hafif bir arayüz sağlar."""
 
 from __future__ import annotations
 

--- a/src/konusan_tohum/memory/__init__.py
+++ b/src/konusan_tohum/memory/__init__.py
@@ -1,1 +1,1 @@
-"""konusan_tohum.memory package."""
+"""Konuşan Tohum hafıza paketi, kullanıcı geçmişini ve profil verilerini kalıcı olarak saklayan yardımcıları içerir."""

--- a/src/konusan_tohum/memory/memory_updater.py
+++ b/src/konusan_tohum/memory/memory_updater.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum hafıza güncelleyicisi, kullanıcı geçmişini dosya tabanlı depoda yönetir ve bağlam servisleriyle senkron tutar."""
+
 import json
 import os
 from pathlib import Path

--- a/src/konusan_tohum/nlp/__init__.py
+++ b/src/konusan_tohum/nlp/__init__.py
@@ -1,1 +1,1 @@
-"""konusan_tohum.nlp package."""
+"""Konuşan Tohum NLP paketi, niyet algılama, varlık çıkarımı, persona oluşturma ve bağlam yönetimini bir araya getirir."""

--- a/src/konusan_tohum/nlp/context_manager.py
+++ b/src/konusan_tohum/nlp/context_manager.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum bağlam yöneticisi, kullanıcı etkileşim geçmişini güncelleyip özetleyerek diyaloğu kişiselleştirir."""
+
 from konusan_tohum.memory.memory_updater import (
     auto_update_memory,
     load_user_memory,

--- a/src/konusan_tohum/nlp/emotion_tracker.py
+++ b/src/konusan_tohum/nlp/emotion_tracker.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum duygu izleyicisi, kullanıcı ruh hali sinyallerini hafif bir kayıt yapısında saklar."""
+
 # nlp/emotion_tracker.py
 
 _emotions = {}

--- a/src/konusan_tohum/nlp/entity_extractor.py
+++ b/src/konusan_tohum/nlp/entity_extractor.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum varlık çıkarıcısı, önceden tanımlı örneklerle kullanıcı mesajlarından anlamlı varlıklar tespit eder."""
+
 import re
 from konusan_tohum.nlp.entity_loader import load_entities
 

--- a/src/konusan_tohum/nlp/entity_loader.py
+++ b/src/konusan_tohum/nlp/entity_loader.py
@@ -1,4 +1,4 @@
-"""Load entity definitions without requiring external dependencies."""
+"""Konuşan Tohum varlık yükleyicisi, YAML tabanlı tanımları okuyarak çıkarım motoruna besler."""
 
 from __future__ import annotations
 

--- a/src/konusan_tohum/nlp/intent_detector.py
+++ b/src/konusan_tohum/nlp/intent_detector.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum niyet dedektörü, dönüştürücü modeller ve manuel eşleştirmeyi harmanlayarak kullanıcı mesajlarını etiketler."""
+
 from konusan_tohum.nlp.intent_loader import load_intents
 
 try:

--- a/src/konusan_tohum/nlp/intent_loader.py
+++ b/src/konusan_tohum/nlp/intent_loader.py
@@ -1,4 +1,4 @@
-"""Utility helpers for loading intent definitions without external deps."""
+"""Konuşan Tohum niyet yükleyicisi, YAML tanımlarını okuyarak niyet örneklerini ve açıklamalarını hazırlar."""
 
 from __future__ import annotations
 

--- a/src/konusan_tohum/nlp/mode_switcher.py
+++ b/src/konusan_tohum/nlp/mode_switcher.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum mod anahtarlayıcısı, niyet sinyallerine göre sohbet kiplerini takip edip günceller."""
+
 # nlp/mode_switcher.py
 
 _modes = {}

--- a/src/konusan_tohum/nlp/nlp_engine.py
+++ b/src/konusan_tohum/nlp/nlp_engine.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum NLP motoru, metin ön işleme ve temel analiz fonksiyonlarını düzenler."""
+
 import re
 
 def preprocess_text(text):

--- a/src/konusan_tohum/nlp/persona_builder.py
+++ b/src/konusan_tohum/nlp/persona_builder.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum persona oluşturucusu, kullanıcı hafızasından stil tercihlerini okuyup diyaloğa yön veren persona profilleri üretir."""
+
 # nlp/persona_builder.py
 from copy import deepcopy
 

--- a/src/konusan_tohum/nlp/yaml_utils.py
+++ b/src/konusan_tohum/nlp/yaml_utils.py
@@ -1,4 +1,4 @@
-"""Minimal YAML helpers tailored to the project's fixture files."""
+"""Konuşan Tohum YAML yardımcıları, NLP örneklerini bağımlılıksız ayrıştırmak için minimal bir yorumlayıcı sunar."""
 
 from __future__ import annotations
 

--- a/src/konusan_tohum/security/__init__.py
+++ b/src/konusan_tohum/security/__init__.py
@@ -1,1 +1,1 @@
-"""konusan_tohum.security package."""
+"""Konuşan Tohum güvenlik paketi, kimlik doğrulama, veri temizliği ve yetki denetimi yardımcılarını barındırır."""

--- a/src/konusan_tohum/security/auth_manager.py
+++ b/src/konusan_tohum/security/auth_manager.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum kimlik doğrulama yöneticisi, temel kullanıcı ve parola eşleşmeleriyle oturum doğruluğunu kontrol eder."""
+
 users = {
     "admin": "1234",
     "guest": "0000"

--- a/src/konusan_tohum/security/data_sanitizer.py
+++ b/src/konusan_tohum/security/data_sanitizer.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum veri temizleyicisi, sohbet girdilerini XSS ve basit enjeksiyon risklerine karşı arındırır."""
+
 import re
 
 def sanitize(text):

--- a/src/konusan_tohum/security/permission_checker.py
+++ b/src/konusan_tohum/security/permission_checker.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum izin denetleyicisi, rol bazlı eylem yetkilendirmesini doğrular."""
+
 permissions = {
     "admin": ["read", "write", "delete"],
     "guest": ["read"]

--- a/src/konusan_tohum/settings/__init__.py
+++ b/src/konusan_tohum/settings/__init__.py
@@ -1,1 +1,1 @@
-"""konusan_tohum.settings package."""
+"""Konuşan Tohum ayarlar paketi, uygulama yapılandırma dosyalarını ve şablonlarını organize eder."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Test yapılandırması için yardımcı fonksiyonlar."""
+"""Konuşan Tohum test ortamı yapılandırması, paket kökünü ve kaynak kodunu testler sırasında içe aktarılabilir hale getirir."""
 
 import sys
 from pathlib import Path

--- a/tests/test_chat_gui.py
+++ b/tests/test_chat_gui.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum masaüstü arayüzünün hafıza ve bağlam panellerini güncellemesini doğrulayan testler."""
+
 import json
 import chat_gui
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum çekirdek bileşenlerinin günlükleme ve yapılandırma davranışını doğrulayan birim testleri."""
+
 from konusan_tohum.core.config_manager import ConfigManager
 from konusan_tohum.core.logger import Logger
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum tanılama katmanının SystemTester akışını denetleyen testler."""
+
 from konusan_tohum.diagnostics.system_tester import SystemTester
 
 def test_system_tester():

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum diyalog yanıtlayıcısının kural tabanlı üretim yollarını sınayan testler."""
+
 import pytest
 
 from konusan_tohum.dialog.response_generator import (

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum entegrasyon katmanının web araması, API istemcisi ve AI köprülerini birlikte doğrulayan senaryolar."""
+
 import builtins
 import importlib
 import sys

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum NLP katmanının niyet ve varlık çıkarımı için sunduğu yolları değerlendiren testler."""
+
 from konusan_tohum.nlp.entity_extractor import extract_entities
 from konusan_tohum.nlp.intent_detector import IntentDetector, detect_intent
 

--- a/tests/test_openrouter_connector.py
+++ b/tests/test_openrouter_connector.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum OpenRouter bağlayıcısının bağımlılık kontrollerini ve hata mesajlarını doğrulayan testler."""
+
 import pytest
 
 from konusan_tohum.dialog import openrouter_connector

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,3 +1,5 @@
+"""Konuşan Tohum güvenlik yardımcılarının veri temizleme süreçlerini sınayan testler."""
+
 from konusan_tohum.security.data_sanitizer import sanitize
 
 def test_data_sanitizer():


### PR DESCRIPTION
## Summary
- add module-level docstrings across the Konuşan Tohum packages and tests to describe each component's responsibility using project terminology
- replace placeholder headers with descriptive explanations in core, dialog, integration, security, NLP, memory, diagnostics, and settings modules
- refresh test helper files with matching docstrings so documentation stays consistent end-to-end

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de30d1d6a48327b23c7858fb0c84f4