### PR TITLE
Expose memory updater APIs via package init

### DIFF
--- a/src/konusan_tohum/memory/__init__.py
+++ b/src/konusan_tohum/memory/__init__.py
@@ -1,1 +1,17 @@
-"""konusan_tohum.memory package."""
+"""Public interface for the :mod:`konusan_tohum.memory` package."""
+
+from .memory_updater import (  # noqa: F401
+    auto_update_memory,
+    get_user_memory,
+    load_user_memory,
+    save_memory,
+    update_memory,
+)
+
+__all__ = [
+    "auto_update_memory",
+    "get_user_memory",
+    "load_user_memory",
+    "save_memory",
+    "update_memory",
+]


### PR DESCRIPTION
## Summary
- re-export memory updater helpers from konusan_tohum.memory
- ensure update_memory is importable from the package root

## Testing
- PYTHONPATH=src python - <<'PY'
from konusan_tohum.memory import update_memory
print(update_memory)
PY

------
https://chatgpt.com/codex/tasks/task_e_68de30d49ec483279f32b2900bd4ab92