### PR TITLE
Add retry configuration to API helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Konuşan Tohum
+
+## API Yardımcı Fonksiyonu
+
+`call_api` yardımcı fonksiyonu, ağ bağlantısı veya `requests` kütüphanesi
+bulunmadığında bile deterministik bir stub döndürerek testlerin güvenli bir
+şekilde çalışmasını sağlar. Fonksiyon artık aşağıdaki yeni parametrelerle
+konfigüre edilebilir:
+
+- **timeout**: Her deneme için `requests.get` çağrısına iletilen zaman aşımı
+  değeri. Varsayılan değer 5 saniyedir ve önceki davranış korunur.
+- **retries**: Hata durumlarında yapılacak ek deneme sayısı. Varsayılan değer
+  0'dır, yani yalnızca tek bir deneme yapılır.
+- **backoff_factor**: Üstel gecikme için temel değer. Her başarısız denemenin
+  ardından `backoff_factor * (2 ** deneme_indeksi)` kadar beklendikten sonra
+  yeniden denenir.
+
+Belirtilen tekrarlar başarısız olsa bile fonksiyon deterministik stub cevabını
+vermeye devam eder.

--- a/src/konusan_tohum/integration/api_connector.py
+++ b/src/konusan_tohum/integration/api_connector.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, Optional
 
+import time
+
 try:
     import openai  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency
@@ -22,40 +24,81 @@ def _build_stub_response(url: str, params: Optional[Dict[str, Any]] = None) -> D
     }
 
 
-def call_api(url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def call_api(
+    url: str,
+    params: Optional[Dict[str, Any]] = None,
+    *,
+    timeout: float = 5,
+    retries: int = 0,
+    backoff_factor: float = 0.5,
+) -> Dict[str, Any]:
     """Lightweight API helper that gracefully falls back to a stub response.
 
-    The function attempts to perform a real HTTP GET using the requests library.
-    When the client library is unavailable or a network error occurs, the
-    function returns a deterministic stub response so that tests can run
-    without external dependencies.
+    Parameters
+    ----------
+    url:
+        Target endpoint for the HTTP GET request.
+    params:
+        Query parameters forwarded to the remote endpoint. The mapping is also
+        used to build the deterministic stub payload when network access is not
+        possible.
+    timeout:
+        Per-request timeout value passed directly to ``requests.get``. Defaults
+        to ``5`` seconds to keep backward compatibility.
+    retries:
+        The number of retry attempts when the HTTP call fails. Retries use an
+        exponential backoff controlled by ``backoff_factor``. ``0`` preserves
+        the previous behaviour and performs a single request attempt.
+    backoff_factor:
+        The base delay in seconds for exponential backoff. Each retry waits for
+        ``backoff_factor * (2 ** attempt_index)`` seconds before retrying. The
+        value is ignored when ``retries`` is set to ``0``.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Successful responses contain the raw payload returned by ``requests``.
+        When the client library is unavailable or network errors persist after
+        exhausting the configured retries, the function returns a deterministic
+        stub response so that tests can run without external dependencies.
     """
 
     params = params or {}
+
+    # Guard against negative retry values to keep behaviour predictable.
+    if retries < 0:
+        retries = 0
 
     try:
         import requests  # Local import to avoid mandatory dependency.
     except ImportError:
         return _build_stub_response(url, params)
 
-    try:
-        response = requests.get(url, params=params, timeout=5)
-        response.raise_for_status()
-        content_type = response.headers.get("Content-Type", "")
-        payload: Any
-        if content_type.startswith("application/json"):
-            payload = response.json()
-        else:
-            payload = response.text
+    for attempt in range(retries + 1):
+        try:
+            response = requests.get(url, params=params, timeout=timeout)
+            response.raise_for_status()
+            content_type = response.headers.get("Content-Type", "")
+            payload: Any
+            if content_type.startswith("application/json"):
+                payload = response.json()
+            else:
+                payload = response.text
 
-        return {
-            "status": "ok",
-            "url": url,
-            "params": params,
-            "data": payload,
-        }
-    except Exception:
-        return _build_stub_response(url, params)
+            return {
+                "status": "ok",
+                "url": url,
+                "params": params,
+                "data": payload,
+            }
+        except Exception:
+            if attempt < retries:
+                # Exponential backoff with deterministic timing for tests.
+                delay = backoff_factor * (2**attempt)
+                if delay > 0:
+                    time.sleep(delay)
+                continue
+            return _build_stub_response(url, params)
 
 class AIConnector:
     def __init__(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,10 +26,65 @@ def test_web_search():
     print("✅ WebSearchMod test edildi.")
 
 
-def test_api_connector():
-    response = call_api("https://api.example.com", {"q": "test"})
-    assert response is not None
+def test_api_connector(monkeypatch):
+    class _DummyResponse:
+        headers = {"Content-Type": "application/json"}
+
+        @staticmethod
+        def raise_for_status():
+            return None
+
+        @staticmethod
+        def json():
+            return {"message": "ok"}
+
+    def _dummy_get(url, params=None, timeout=None):
+        return _DummyResponse()
+
+    dummy_requests = types.SimpleNamespace(get=_dummy_get)
+    monkeypatch.setitem(sys.modules, "requests", dummy_requests)
+
+    response = call_api("https://api.example.com", {"q": "test"}, timeout=3)
+
+    assert response["status"] == "ok"
+    assert response["data"] == {"message": "ok"}
+    assert response["params"] == {"q": "test"}
     print("✅ APIConnector test edildi.")
+
+
+def test_call_api_retries_return_stub(monkeypatch):
+    attempts = []
+
+    def _failing_get(url, params=None, timeout=None):
+        attempts.append({"timeout": timeout, "params": params})
+        raise RuntimeError("boom")
+
+    dummy_requests = types.SimpleNamespace(get=_failing_get)
+    monkeypatch.setitem(sys.modules, "requests", dummy_requests)
+
+    sleeps = []
+    monkeypatch.setattr(
+        "konusan_tohum.integration.api_connector.time.sleep",
+        lambda duration: sleeps.append(duration),
+    )
+
+    response = call_api(
+        "https://api.example.com",
+        {"q": "retry"},
+        timeout=7,
+        retries=2,
+        backoff_factor=0.1,
+    )
+
+    assert response == {
+        "status": "stub",
+        "url": "https://api.example.com",
+        "params": {"q": "retry"},
+        "data": "stub-response-for-https://api.example.com",
+    }
+    assert len(attempts) == 3
+    assert all(call["timeout"] == 7 for call in attempts)
+    assert sleeps == [0.1, 0.2]
 
 
 def test_ai_connector_offline_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
- add configurable timeout, retry count, and exponential backoff to `call_api`
- document the new parameters while keeping the deterministic stub fallback
- update integration tests to cover both successful and retry scenarios

## Testing
- pytest tests/test_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68de30d54294832784127a12a117ab2d