### PR TITLE
Ensure ModuleLoader normalizes generation interface

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,12 @@ def initialize_system():
 
     # Modülleri yükle
     loader = ModuleLoader(active_modules)
-    loader.load_all()
+    try:
+        loader.load_all()
+    except Exception as exc:
+        print(f"❌ Modül yüklenemedi: {exc}")
+        return
+
     modules = loader.get_all_modules()
 
     # Modül testi

--- a/src/konusan_tohum/core/module_loader.py
+++ b/src/konusan_tohum/core/module_loader.py
@@ -7,17 +7,45 @@ class ModuleLoader:
         self.modules = {}
         self.logger = logging.getLogger("ModuleLoader")
 
+    def _ensure_generation_interface(self, name, target):
+        has_generate = hasattr(target, "generate")
+        has_generate_response = hasattr(target, "generate_response")
+
+        if has_generate and not has_generate_response:
+            setattr(target, "generate_response", getattr(target, "generate"))
+            self.logger.debug(
+                "Modül %s için 'generate' fonksiyonu 'generate_response' olarak aliaslandı.",
+                name,
+            )
+        elif has_generate_response and not has_generate:
+            setattr(target, "generate", getattr(target, "generate_response"))
+            self.logger.debug(
+                "Modül %s için 'generate_response' fonksiyonu 'generate' olarak aliaslandı.",
+                name,
+            )
+        elif not has_generate and not has_generate_response:
+            message = (
+                f"{name} modülünde 'generate' ve 'generate_response' fonksiyonları tanımlı değil."
+            )
+            self.logger.error(message)
+            raise AttributeError(message)
+
     def load_all(self):
         for name in self.module_names:
             try:
                 module = importlib.import_module(name)
                 if hasattr(module, "initialize"):
-                    self.modules[name] = module.initialize()
+                    target = module.initialize()
                 else:
-                    self.modules[name] = module
+                    target = module
+
+                self._ensure_generation_interface(name, target)
+
+                self.modules[name] = target
                 self.logger.info(f"Modül yüklendi: {name}")
             except Exception as e:
                 self.logger.error(f"Modül yüklenemedi: {name} → {e}")
+                raise
 
     def get_module(self, name):
         return self.modules.get(name, None)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,11 @@
+import sys
+import types
+
+import pytest
+
 from konusan_tohum.core.config_manager import ConfigManager
 from konusan_tohum.core.logger import Logger
+from konusan_tohum.core.module_loader import ModuleLoader
 
 def test_logger():
     logger = Logger()
@@ -11,3 +17,61 @@ def test_config_manager():
     settings = config.load_config()
     assert isinstance(settings, dict)
     print("✅ ConfigManager test edildi.")
+
+
+def test_module_loader_aliases_generate_to_generate_response():
+    module_name = "tests.dummy.generate_only"
+    module = types.ModuleType(module_name)
+
+    def generate(*args, **kwargs):
+        return "generated"
+
+    module.generate = generate
+    sys.modules[module_name] = module
+
+    try:
+        loader = ModuleLoader([module_name])
+        loader.load_all()
+        loaded = loader.get_module(module_name)
+        assert loaded.generate is loaded.generate_response
+        assert loaded.generate("test") == "generated"
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def test_module_loader_aliases_generate_response_to_generate():
+    module_name = "tests.dummy.response_only"
+    module = types.ModuleType(module_name)
+
+    class Generator:
+        def generate_response(self, *args, **kwargs):
+            return "response"
+
+    def initialize():
+        return Generator()
+
+    module.initialize = initialize
+    sys.modules[module_name] = module
+
+    try:
+        loader = ModuleLoader([module_name])
+        loader.load_all()
+        loaded = loader.get_module(module_name)
+        assert hasattr(loaded, "generate")
+        assert loaded.generate("test") == "response"
+        assert loaded.generate.__func__ is loaded.generate_response.__func__
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def test_module_loader_raises_when_generation_missing():
+    module_name = "tests.dummy.missing_generation"
+    module = types.ModuleType(module_name)
+    sys.modules[module_name] = module
+
+    try:
+        loader = ModuleLoader([module_name])
+        with pytest.raises(AttributeError):
+            loader.load_all()
+    finally:
+        sys.modules.pop(module_name, None)


### PR DESCRIPTION
## Summary
- ensure ModuleLoader aliases missing generate/generate_response symbols and raises a clear error when both are absent
- update the main entrypoint to surface module loading failures gracefully
- add unit tests covering the new ModuleLoader behaviour

## Testing
- pytest tests/test_core.py

------
https://chatgpt.com/codex/tasks/task_e_68de30d99c908327b2ad612a0aebdec5