### PR TITLE
Add pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+testpaths = tests
+pythonpath = src
+addopts = -ra --strict-markers
+filterwarnings =
+    error::DeprecationWarning
+    ignore::UserWarning


### PR DESCRIPTION
## Summary
- add a pytest.ini file that sets default test paths and pythonpath
- configure pytest addopts and warning filters for consistent behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de60456a6083279d46fc6254f20325