### PR TITLE
Expose update_memory at package root

### DIFF
--- a/src/konusan_tohum/__init__.py
+++ b/src/konusan_tohum/__init__.py
@@ -1,4 +1,9 @@
-"""konusan_tohum package root."""
+"""konusan_tohum package root.
+
+Re-export selected utilities for convenient access at the package level.
+"""
+
+from .memory import update_memory
 
 __all__ = [
     "core",
@@ -9,4 +14,5 @@ __all__ = [
     "security",
     "settings",
     "diagnostics",
+    "update_memory",
 ]


### PR DESCRIPTION
## Summary
- re-export `update_memory` from the package root for easier access
- document the convenience re-export in the module docstring

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de60489a78832795f51cd443d51913