### PR TITLE
Add validation for dialog response aliases

### DIFF
--- a/src/konusan_tohum/dialog/response_generator.py
+++ b/src/konusan_tohum/dialog/response_generator.py
@@ -20,6 +20,28 @@ _INTENT_ALIASES = {
     "farewell": "goodbye",
 }
 
+
+def _validate_aliases(aliases, responses):
+    """Alias hedeflerinin tanımlı kural tabanlı yanıtları gösterdiğini doğrula."""
+
+    invalid_mappings = {
+        alias: target
+        for alias, target in aliases.items()
+        if target not in responses
+    }
+
+    if invalid_mappings:
+        details = ", ".join(
+            f"'{alias}' -> '{target}'" for alias, target in sorted(invalid_mappings.items())
+        )
+        raise ValueError(
+            "Geçersiz intent alias(lar)ı bulundu: "
+            f"{details}. Alias değerleri RULE_BASED_RESPONSES anahtarlarıyla eşleşmelidir."
+        )
+
+
+_validate_aliases(_INTENT_ALIASES, RULE_BASED_RESPONSES)
+
 __all__ = ["RULE_BASED_RESPONSES", "generate_response", "generate"]
 
 _GENERATOR = None

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -32,6 +32,18 @@ def test_rule_based_aliases_present(intent):
     assert response
 
 
+def test_intent_alias_validation_error():
+    """Alias değeri tanımlı yanıt anahtarlarıyla örtüşmediğinde hata üretilmeli."""
+
+    from konusan_tohum.dialog import response_generator as rg
+
+    invalid_aliases = dict(rg._INTENT_ALIASES)
+    invalid_aliases["bilinmeyen"] = "nonexistent"
+
+    with pytest.raises(ValueError, match="Geçersiz intent alias"):
+        rg._validate_aliases(invalid_aliases, rg.RULE_BASED_RESPONSES)
+
+
 def test_generate_matches_generate_response(monkeypatch):
     """Serbest üretim akışında `generate` ve `generate_response` aynı çıktıyı vermeli."""
 


### PR DESCRIPTION
## Summary
- validate intent alias mappings against available rule-based responses during module import
- raise a descriptive exception when an alias points to an undefined response key
- add a unit test covering the alias validation error path

## Testing
- pytest tests/test_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_68de604923a48327b11f156424eafcdb