### PR TITLE
Add tests for auto update memory history test

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,6 +1,7 @@
 import json
 
 from konusan_tohum.memory import update_memory
+from konusan_tohum.memory.memory_updater import auto_update_memory
 
 
 def test_update_memory_appends_history_and_persists_json(tmp_path):
@@ -18,3 +19,43 @@ def test_update_memory_appends_history_and_persists_json(tmp_path):
     assert len(history) == 2
     assert history[0] == {"message": "Selam", "response": "Merhaba!"}
     assert history[1] == {"message": "Nasılsın?", "response": "İyiyim, teşekkürler!"}
+
+
+def test_auto_update_memory_persists_intent_entities_and_limits_history(tmp_path):
+    memory_file = tmp_path / "user_memory.json"
+    user_id = "auto-user"
+
+    auto_update_memory(
+        user_id,
+        "İlk mesaj",
+        intent="selamlama",
+        entities={"isim": "Ahmet"},
+        memory_file=memory_file,
+    )
+
+    for i in range(25):
+        auto_update_memory(
+            user_id,
+            f"Mesaj {i}",
+            intent=f"intent_{i}",
+            entities={"index": i},
+            memory_file=memory_file,
+        )
+
+    with memory_file.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert user_id in data
+    history = data[user_id]["history"]
+
+    assert len(history) == 20
+    assert history[0]["message"] == "Mesaj 5"
+    assert history[-1] == {
+        "message": "Mesaj 24",
+        "intent": "intent_24",
+        "entities": {"index": 24},
+    }
+
+    for entry in history:
+        assert "intent" in entry
+        assert "entities" in entry


### PR DESCRIPTION
## Summary
- add coverage for auto_update_memory to ensure intent and entity fields persist
- verify user history truncates to the maximum of 20 records

## Testing
- pytest tests/test_memory.py

------
https://chatgpt.com/codex/tasks/task_e_68de604c1c2c832788cb0d4e79788ea2