### PR TITLE
Add import error stub fallback test for call_api

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,7 +38,11 @@ if "transformers" not in sys.modules:
     transformers_stub.pipeline = _stub_pipeline
     sys.modules["transformers"] = transformers_stub
 
-from konusan_tohum.integration.api_connector import AIConnector, call_api
+from konusan_tohum.integration.api_connector import (
+    AIConnector,
+    _build_stub_response,
+    call_api,
+)
 from konusan_tohum.integration.web_search_mod import search
 
 
@@ -112,6 +116,27 @@ def test_call_api_timeout_retries_and_stub():
     }
     assert mock_get.call_count == 3
     mock_sleep.assert_has_calls([call(0.5), call(1.0)])
+
+
+def test_call_api_import_error_returns_stub(monkeypatch):
+    monkeypatch.delitem(sys.modules, "requests", raising=False)
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "requests":
+            raise ImportError("blocked requests")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    url = "https://api.example.com/import-error"
+    params = {"x": 42, "a": "b"}
+
+    result = call_api(url, params)
+    expected = _build_stub_response(url, params)
+
+    assert result == expected
 
 
 def test_ai_connector_offline_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
- add coverage ensuring call_api returns stub response when requests import fails
- compare the result with _build_stub_response to verify matching structure
- use monkeypatch to cleanly remove the import override after the test

## Testing
- pytest tests/test_integration.py::test_call_api_import_error_returns_stub

------
https://chatgpt.com/codex/tasks/task_e_68de61446a508327b60d9d5f53ad6692